### PR TITLE
Added chrono-style clock

### DIFF
--- a/include/maidsafe/common/clock.h
+++ b/include/maidsafe/common/clock.h
@@ -1,0 +1,55 @@
+/*  Copyright 2014 MaidSafe.net limited
+
+    This MaidSafe Software is licensed to you under (1) the MaidSafe.net Commercial License,
+    version 1.0 or later, or (2) The General Public License (GPL), version 3, depending on which
+    licence you accepted on initial access to the Software (the "Licences").
+
+    By contributing code to the MaidSafe Software, or to this project generally, you agree to be
+    bound by the terms of the MaidSafe Contributor Agreement, version 1.0, found in the root
+    directory of this project at LICENSE, COPYING and CONTRIBUTOR respectively and also
+    available at: http://www.maidsafe.net/licenses
+
+    Unless required by applicable law or agreed to in writing, the MaidSafe Software distributed
+    under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+    OF ANY KIND, either express or implied.
+
+    See the Licences for the specific language governing permissions and limitations relating to
+    use of the MaidSafe Software.                                                                 */
+
+#ifndef MAIDSAFE_COMMON_CLOCK_H_
+#define MAIDSAFE_COMMON_CLOCK_H_
+
+#include <chrono>
+
+#include "maidsafe/common/config.h"
+
+namespace maidsafe {
+namespace common {
+
+// Chrono clock that uses UTC from epoch 1970-01-01T00:00:00Z with 1 nanosecond resolution.
+// The resolution accuracy depends on the system clock.
+struct Clock {
+  typedef std::chrono::nanoseconds duration;
+  typedef duration::rep rep;
+  typedef duration::period period;
+  typedef std::chrono::time_point<Clock> time_point;
+
+  static const bool is_steady = std::chrono::system_clock::is_steady;
+
+  // Returns the current time.
+  //
+  // Assumes that chrono::system_clock uses 1970-01-01 as epoch. If this assumption does not
+  // hold, then the MAIDSAFE_CLOCK_EPOCH_OFFSET_IN_DAYS can be defined to the number of days
+  // from 1970-01-01 until the chrono::system_clock epoch.
+  static time_point now() MAIDSAFE_NOEXCEPT;
+
+  // Convert time_point to time_t
+  static std::time_t to_time_t(const time_point&);
+  // Convert time_t to time_point
+  static time_point from_time_t(std::time_t);
+};
+
+}  // namespace common
+}  // namespace maidsafe
+
+#endif  // MAIDSAFE_COMMON_CLOCK_H_

--- a/src/maidsafe/common/clock.cc
+++ b/src/maidsafe/common/clock.cc
@@ -1,0 +1,42 @@
+/*  Copyright 2014 MaidSafe.net limited
+
+    This MaidSafe Software is licensed to you under (1) the MaidSafe.net Commercial License,
+    version 1.0 or later, or (2) The General Public License (GPL), version 3, depending on which
+    licence you accepted on initial access to the Software (the "Licences").
+
+    By contributing code to the MaidSafe Software, or to this project generally, you agree to be
+    bound by the terms of the MaidSafe Contributor Agreement, version 1.0, found in the root
+    directory of this project at LICENSE, COPYING and CONTRIBUTOR respectively and also
+    available at: http://www.maidsafe.net/licenses
+
+    Unless required by applicable law or agreed to in writing, the MaidSafe Software distributed
+    under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+    OF ANY KIND, either express or implied.
+
+    See the Licences for the specific language governing permissions and limitations relating to
+    use of the MaidSafe Software.                                                                 */
+
+#include "maidsafe/common/clock.h"
+
+namespace maidsafe {
+namespace common {
+
+Clock::time_point Clock::now() MAIDSAFE_NOEXCEPT {
+  auto time_now = std::chrono::system_clock::now();
+  // Assumes that system_clock uses 1970-01-01 as epoch
+#if defined(MAIDSAFE_CLOCK_EPOCH_OFFSET_IN_DAYS)
+  time_now += std::chrono::days(MAIDSAFE_CLOCK_EPOCH_OFFSET_IN_DAYS);
+#endif
+  return time_point(std::chrono::duration_cast<duration>(time_now.time_since_epoch()));
+}
+
+std::time_t Clock::to_time_t(const time_point& t) {
+  return std::chrono::duration_cast<std::chrono::seconds>(t.time_since_epoch()).count();
+}
+
+Clock::time_point Clock::from_time_t(std::time_t t) {
+  return time_point(std::chrono::seconds(t));
+}
+
+}  // namespace common
+}  // namespace maidsafe

--- a/src/maidsafe/common/tests/clock_test.cc
+++ b/src/maidsafe/common/tests/clock_test.cc
@@ -1,0 +1,37 @@
+/*  Copyright 2014 MaidSafe.net limited
+
+    This MaidSafe Software is licensed to you under (1) the MaidSafe.net Commercial License,
+    version 1.0 or later, or (2) The General Public License (GPL), version 3, depending on which
+    licence you accepted on initial access to the Software (the "Licences").
+
+    By contributing code to the MaidSafe Software, or to this project generally, you agree to be
+    bound by the terms of the MaidSafe Contributor Agreement, version 1.0, found in the root
+    directory of this project at LICENSE, COPYING and CONTRIBUTOR respectively and also
+    available at: http://www.maidsafe.net/licenses
+
+    Unless required by applicable law or agreed to in writing, the MaidSafe Software distributed
+    under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+    OF ANY KIND, either express or implied.
+
+    See the Licences for the specific language governing permissions and limitations relating to
+    use of the MaidSafe Software.                                                                 */
+
+#include "maidsafe/common/clock.h"
+#include "maidsafe/common/test.h"
+
+namespace maidsafe {
+namespace test {
+
+TEST(ClockTest, BEH_TimeConversion) {
+  auto result = common::Clock::from_time_t(42);
+  EXPECT_EQ(result.time_since_epoch(), std::chrono::seconds(42));
+}
+
+TEST(ClockTest, BEH_TimePointConversion) {
+  common::Clock::time_point tp(std::chrono::seconds(43));
+  auto result = common::Clock::to_time_t(tp);
+  EXPECT_EQ(result, 43);
+}
+
+}  // namespace test
+}  // namespace maidsafe


### PR DESCRIPTION
This is a std::chrono style clock that can be used with std::chrono calculations.

It appears that there is no guarantee in the C++ standard about the epoch, but it is 1970-01-01 on all our current targets. If it deviates, then I have added the MAIDSAFE_CLOCK_EPOCH_OFFSET_IN_DAYS macro to adjust the epoch. This solution has no performance impact on our current targets (and a minimal impact on future targets that may deviate.)
