### PR TITLE
Moved Clock from maidsafe::common to maidsafe namespace

### DIFF
--- a/include/maidsafe/common/clock.h
+++ b/include/maidsafe/common/clock.h
@@ -24,7 +24,6 @@
 #include "maidsafe/common/config.h"
 
 namespace maidsafe {
-namespace common {
 
 // Chrono clock that uses UTC from epoch 1970-01-01T00:00:00Z with 1 nanosecond resolution.
 // The resolution accuracy depends on the system clock.
@@ -49,7 +48,10 @@ struct Clock {
   static time_point from_time_t(std::time_t);
 };
 
+namespace common {
+using Clock = maidsafe::Clock;
 }  // namespace common
+
 }  // namespace maidsafe
 
 #endif  // MAIDSAFE_COMMON_CLOCK_H_

--- a/src/maidsafe/common/clock.cc
+++ b/src/maidsafe/common/clock.cc
@@ -19,7 +19,6 @@
 #include "maidsafe/common/clock.h"
 
 namespace maidsafe {
-namespace common {
 
 Clock::time_point Clock::now() MAIDSAFE_NOEXCEPT {
   auto time_now = std::chrono::system_clock::now();
@@ -38,5 +37,4 @@ Clock::time_point Clock::from_time_t(std::time_t t) {
   return time_point(std::chrono::seconds(t));
 }
 
-}  // namespace common
 }  // namespace maidsafe


### PR DESCRIPTION
There is an alias for maidsafe::common::Clock so that modules that currently use this will continue to work.
