### PR TITLE
MAID-512 Improve Log Performance

### DIFF
--- a/include/maidsafe/common/log.h
+++ b/include/maidsafe/common/log.h
@@ -65,7 +65,6 @@ namespace detail {
     typedef typename std::add_const<Right>::type BoundRight;
 
    public:
-
     OstreamBinder(BoundLeft& left, BoundRight& right)
       : left_(left),
         right_(right) {
@@ -76,7 +75,6 @@ namespace detail {
     }
 
    private:
-
     BoundLeft& left_;
     BoundRight& right_;
   };
@@ -84,7 +82,6 @@ namespace detail {
   template<>
   class OstreamBinder<void, void> {
    public:
-
     void Serialise(std::ostream&) const {}
   };
 
@@ -140,7 +137,7 @@ namespace detail {
     const char* const file_;
     const int level_;
   };
-}
+}  // namespace detail
 
 // Convert to map<string, int, std::less<>> when C++14 mode is enabled
 typedef std::map<std::string, int> FilterMap;
@@ -166,7 +163,8 @@ const int kVerbose = -1, kInfo = 0, kSuccess = 1, kWarning = 2, kError = 3, kAlw
   maidsafe::log::detail::LogMessage(__FILE__, maidsafe::log::level) =               \
       maidsafe::log::detail::OstreamBinder<void, void>() << ":" << __LINE__ << "] "
 #else
-#define LOG(_) maidsafe::log::detail::NullStream() = maidsafe::log::detail::OstreamBinder<void, void>()
+#define LOG(_) maidsafe::log::detail::NullStream() = \
+    maidsafe::log::detail::OstreamBinder<void, void>()
 #endif
 #define TLOG(colour) maidsafe::log::TestLogMessage(maidsafe::log::Colour::colour).MessageStream()
 

--- a/src/maidsafe/common/log.cc
+++ b/src/maidsafe/common/log.cc
@@ -182,7 +182,7 @@ std::pair<boost::string_ref, boost::string_ref> GetProjectAndContractFile(
     return { boost::string_ref(), entire_path };
   }
 
-  filename.remove_prefix(1); // remove leading slash
+  filename.remove_prefix(1);  // remove leading slash
 
   const auto dir_separator = {'/', '\\'};
   auto project =
@@ -452,7 +452,7 @@ void LogMessage::Log(const std::string& project, std::string message) const {
   Logging::Instance().Async() ? Logging::Instance().Send(print_functor) : print_functor();
 }
 
-} // namespace detail
+}  // namespace detail
 
 
 // ===================================== TestLogMessage ============================================


### PR DESCRIPTION
Tested this in OSX, Windows, and Linux. There should be no changes in behavior, other than performance increase when logging is enabled.

There are no tests for log, which is a bit concerning. If you want me to add some, let me know. It will be difficult, but it should be possible.
