### PR TITLE
Adding SipHash, and the proposed N3980.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,10 @@ ms_glob_dir(CommonContainersTests ${CommonSourcesDir}/containers/tests "Containe
 ms_glob_dir(CommonDataTypes ${CommonSourcesDir}/data_types "Data Types")
 ms_glob_dir(CommonDataTypesTests ${CommonSourcesDir}/data_types/tests "Data Types Tests")
 
+ms_glob_dir(CommonHashAlgorithms ${CommonSourcesDir}/hash/algorithms "Hash algorithms")
+ms_glob_dir(CommonHashDefinitions ${CommonSourcesDir}/hash "Hash definitions")
+ms_glob_dir(CommonHashTests ${CommonSourcesDir}/hash/tests "Hash Tests")
+
 ms_glob_dir(CommonSerialisation ${CommonSourcesDir}/serialisation "Serialisation")
 ms_glob_dir(CommonSerialisationTypes ${CommonSourcesDir}/serialisation/types "Serialisation Types")
 ms_glob_dir(CommonSerialisationTests ${CommonSourcesDir}/serialisation/tests "Serialisation Tests")
@@ -84,6 +88,8 @@ ms_add_static_library(maidsafe_common
     ${CommonAuthenticationDetailAllFiles}
     ${CommonContainersAllFiles}
     ${CommonDataTypesAllFiles}
+    ${CommonHashAlgorithmsAllFiles}
+    ${CommonHashDefinitionsAllFiles}
     ${CommonSerialisationAllFiles}
     ${CommonSerialisationTypesAllFiles}
     ${CommonTcpAllFiles})
@@ -173,6 +179,7 @@ if(INCLUDE_TESTS)
   ms_add_executable(test_common "Tests/Common"
       ${CommonTestsAllFiles}
       ${CommonAuthenticationTestsAllFiles}
+      ${CommonHashTestsAllFiles}
       ${CommonTcpTestsAllFiles}
       ${CommonContainersTestsAllFiles}
       ${CommonDataTypesTestsAllFiles}

--- a/common_flags.cmake
+++ b/common_flags.cmake
@@ -180,3 +180,7 @@ target_compile_options(maidsafe_common
         $<$<CXX_COMPILER_ID:GNU>:-static-libstdc++ -Wstrict-null-sentinel>
     >
 )
+
+if(INCLUDE_TESTS)
+  target_compile_options(test_common PUBLIC $<$<BOOL:${MSVC}>: /bigobj>)
+endif()

--- a/include/maidsafe/common/hash.h
+++ b/include/maidsafe/common/hash.h
@@ -1,0 +1,40 @@
+/*  Copyright 2014 MaidSafe.net limited
+
+    This MaidSafe Software is licensed to you under (1) the MaidSafe.net Commercial License,
+    version 1.0 or later, or (2) The General Public License (GPL), version 3, depending on which
+    licence you accepted on initial access to the Software (the "Licences").
+
+    By contributing code to the MaidSafe Software, or to this project generally, you agree to be
+    bound by the terms of the MaidSafe Contributor Agreement, version 1.0, found in the root
+    directory of this project at LICENSE, COPYING and CONTRIBUTOR respectively and also
+    available at: http://www.maidsafe.net/licenses
+
+    Unless required by applicable law or agreed to in writing, the MaidSafe Software distributed
+    under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+    OF ANY KIND, either express or implied.
+
+    See the Licences for the specific language governing permissions and limitations relating to
+    use of the MaidSafe Software.                                                                 */
+#ifndef MAIDSAFE_COMMON_HASH_H_
+#define MAIDSAFE_COMMON_HASH_H_
+
+#include "maidsafe/common/hash/hash_algorithms.h"
+#include "maidsafe/common/hash/hash_array.h"
+#include "maidsafe/common/hash/hash_contiguous.h"
+#include "maidsafe/common/hash/hash_data_range.h"
+#include "maidsafe/common/hash/hash_forward_list.h"
+#include "maidsafe/common/hash/hash_initializer_list.h"
+#include "maidsafe/common/hash/hash_iterator_range.h"
+#include "maidsafe/common/hash/hash_list.h"
+#include "maidsafe/common/hash/hash_map.h"
+#include "maidsafe/common/hash/hash_numeric.h"
+#include "maidsafe/common/hash/hash_pair.h"
+#include "maidsafe/common/hash/hash_range.h"
+#include "maidsafe/common/hash/hash_set.h"
+#include "maidsafe/common/hash/hash_string.h"
+#include "maidsafe/common/hash/hash_string_ref.h"
+#include "maidsafe/common/hash/hash_tuple.h"
+#include "maidsafe/common/hash/hash_vector.h"
+#include "maidsafe/common/hash/hash_wrappers.h"
+
+#endif  // MAIDSAFE_COMMON_HASH_H_

--- a/include/maidsafe/common/hash/algorithms/hash_algorithm_base.h
+++ b/include/maidsafe/common/hash/algorithms/hash_algorithm_base.h
@@ -1,0 +1,224 @@
+/*  Copyright 2014 MaidSafe.net limited
+
+    This MaidSafe Software is licensed to you under (1) the MaidSafe.net Commercial License,
+    version 1.0 or later, or (2) The General Public License (GPL), version 3, depending on which
+    licence you accepted on initial access to the Software (the "Licences").
+
+    By contributing code to the MaidSafe Software, or to this project generally, you agree to be
+    bound by the terms of the MaidSafe Contributor Agreement, version 1.0, found in the root
+    directory of this project at LICENSE, COPYING and CONTRIBUTOR respectively and also
+    available at: http://www.maidsafe.net/licenses
+
+    Unless required by applicable law or agreed to in writing, the MaidSafe Software distributed
+    under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+    OF ANY KIND, either express or implied.
+
+    See the Licences for the specific language governing permissions and limitations relating to
+    use of the MaidSafe Software.                                                                 */
+#ifndef MAIDSAFE_COMMON_HASH_ALGORITHMS_HASH_ALGORITHM_BASE_H_
+#define MAIDSAFE_COMMON_HASH_ALGORITHMS_HASH_ALGORITHM_BASE_H_
+
+#include <type_traits>
+#include <utility>
+
+#include "maidsafe/common/hash/hash_use_serialize.h"
+
+namespace maidsafe {
+namespace detail {
+
+template<typename Derived>
+class HashAlgorithmBase {
+  static_assert(!std::is_pointer<Derived>::value, "Bad used of CRTP");
+  static_assert(!std::is_reference<Derived>::value, "Bad used of CRTP");
+
+ public:
+  template<typename... Args>
+  void operator()(Args&&... param) {
+    Process(std::forward<Args>(param)...);
+  }
+
+  template<typename Arg>
+  Derived& operator&(Arg&& param) {
+    Process(std::forward<Arg>(param));
+    return *self();
+  }
+
+ private:
+  const Derived* self() const { return static_cast<const Derived*>(this); }
+  Derived* self() { return static_cast<Derived*>(this); }
+
+  template<typename Type>
+  using Normalize =
+    typename std::remove_reference<typename std::remove_cv<Type>::type>::type;
+
+  template<typename Type>
+  using IsVersionIntegral =
+    std::integral_constant<
+      bool,
+      std::is_integral<typename HashVersion<Type>::value_type>::value>;
+
+  //
+  // Traits for selecting which function to call. VS 2013 doesn't
+  // have SFINAE expression support, so get creative
+  //
+  template<typename> struct FunctionExists {};
+
+  template<typename Function, typename... Args>
+  struct FunctionExists<Function(Args...)> {
+    template<typename TestFunction, typename... TestArgs>
+    static auto Check(int)  //NOLINT  - Cpplint incorrectly thinks this is a cast
+      -> decltype(std::declval<TestFunction>()(std::declval<TestArgs>()...), std::true_type());
+
+    template<typename, typename...>
+    static std::false_type Check(...);
+
+    static const bool value =
+        std::is_same<decltype(Check<Function, Args...>(0)), std::true_type>::value;
+  };
+
+  template<typename Function>
+  using Has = std::integral_constant<bool, FunctionExists<Function>::value>;
+
+  template<typename Function>
+  using EnableIfHas = typename std::enable_if<FunctionExists<Function>::value>::type;
+
+  struct HashAppendFunction {
+    struct MemberFunction {
+      template<typename Type>
+      auto operator()(Derived& hash, Type&& type) const
+          -> decltype(std::forward<Type>(type).HashAppend(hash)) {
+        return std::forward<Type>(type).HashAppend(hash);
+      }
+    };
+
+    struct NonMemberFunction {
+      template<typename Type>
+      auto operator()(Derived& hash, Type&& type) const
+          -> decltype(HashAppend(hash, std::forward<Type>(type))) {
+        return HashAppend(hash, std::forward<Type>(type));
+      }
+    };
+
+    template<typename Type>
+    EnableIfHas<MemberFunction(Derived&, Type)> operator()(
+        Derived& hash, Type&& type) const {
+      MemberFunction{}(hash, std::forward<Type>(type));
+    }
+
+    template<typename Type>
+    EnableIfHas<NonMemberFunction(Derived&, Type)> operator()(
+        Derived& hash, Type&& type) const {
+      NonMemberFunction{}(hash, std::forward<Type>(type));
+    }
+  };
+
+  struct SerializeFunction {
+    struct MemberFunction {
+      template<typename Type>
+      auto operator()(Derived& hash, Type&& type) const
+          -> decltype(std::forward<Type>(type).serialize(hash)) {
+        return std::forward<Type>(type).serialize(hash);
+      }
+    };
+
+    struct MemberFunctionWithVersion {
+      template<typename Type>
+      auto operator()(Derived& hash, Type&& type) const
+          -> decltype(std::forward<Type>(type).serialize(hash, std::declval<unsigned>())) {
+        static_assert(
+            IsVersionIntegral<Normalize<Type>>::value,
+            "version must provide integral value");
+        return std::forward<Type>(type).serialize(hash, HashVersion<Normalize<Type>>{});
+      }
+    };
+
+    struct NonMemberFunction {
+      template<typename Type>
+      auto operator()(Derived& hash, Type&& type) const
+          -> decltype(serialize(hash, std::forward<Type>(type))) {
+        return serialize(hash, std::forward<Type>(type));
+      }
+    };
+
+    struct NonMemberFunctionWithVersion {
+      template<typename Type>
+      auto operator()(Derived& hash, Type&& type) const
+          -> decltype(serialize(hash, std::forward<Type>(type), std::declval<unsigned>())) {
+        static_assert(
+            IsVersionIntegral<Normalize<Type>>::value,
+            "version must provide integral value");
+        return serialize(hash, std::forward<Type>(type), HashVersion<Normalize<Type>>{});
+      }
+    };
+
+    template<typename Type>
+    EnableIfHas<MemberFunction(Derived&, Type)> operator()(
+        Derived& hash, Type&& type) const {
+      MemberFunction{}(hash, std::forward<Type>(type));
+    }
+
+    template<typename Type>
+    EnableIfHas<NonMemberFunction(Derived&, Type)> operator()(
+        Derived& hash, Type&& type) const {
+      NonMemberFunction{}(hash, std::forward<Type>(type));
+    }
+
+    template<typename Type>
+    EnableIfHas<MemberFunctionWithVersion(Derived&, Type)> operator()(
+        Derived& hash, Type&& type) const {
+      MemberFunctionWithVersion{}(hash, std::forward<Type>(type));
+    }
+
+    template<typename Type>
+    EnableIfHas<NonMemberFunctionWithVersion(Derived&, Type)> operator()(
+        Derived& hash, Type&& type) const {
+      NonMemberFunctionWithVersion{}(hash, std::forward<Type>(type));
+    }
+  };
+
+  //
+  // Process function which select which stand-alone function
+  // to call (or signal failure)
+  //
+  template<typename Head, typename... Tail>
+  void Process(Head&& param, Tail&&... params) {
+    Process(std::forward<Head>(param));
+    Process(std::forward<Tail>(params)...);
+  }
+
+  template<typename Arg>
+  void Process(Arg&& param) {
+    InvokeHashAppend(std::forward<Arg>(param), Has<HashAppendFunction(Derived&, Arg)>{});
+  }
+
+  void Process() {}
+
+  template<typename Arg>
+  void InvokeHashAppend(Arg&& param, std::true_type) {
+    HashAppendFunction{}(*self(), std::forward<Arg>(param));
+  }
+
+  template<typename Arg>
+  void InvokeHashAppend(Arg&& param, std::false_type) {
+    static_assert(
+        Has<SerializeFunction(Derived&, Arg)>::value,
+        "This type does not have a HashAppend or serialize function");
+    InvokeSerialize(std::forward<Arg>(param), Has<SerializeFunction(Derived&, Arg)>{});
+  }
+
+  template<typename Arg>
+  void InvokeSerialize(Arg&& param, std::true_type) {
+    static_assert(
+        UseSerializeForHashing<typename std::remove_reference<Arg>::type>::value,
+        "This type has a serialize method, but hash support has not been enabled");
+    SerializeFunction{}(*self(), std::forward<Arg>(param));
+  }
+
+  template<typename Arg>
+  void InvokeSerialize(Arg&&, std::false_type);
+};
+
+}  // namespace detail
+}  // namespace maidsafe
+
+#endif  // MAIDSAFE_COMMON_HASH_ALGORITHMS_HASH_ALGORITHM_BASE_H_

--- a/include/maidsafe/common/hash/algorithms/hash_algorithm_base.h
+++ b/include/maidsafe/common/hash/algorithms/hash_algorithm_base.h
@@ -32,9 +32,9 @@ class HashAlgorithmBase {
   static_assert(!std::is_reference<Derived>::value, "Bad used of CRTP");
 
  public:
-  template<typename... Args>
-  void operator()(Args&&... param) {
-    Process(std::forward<Args>(param)...);
+  template<typename Arg, typename... Args>
+  void operator()(Arg&& param, Args&&... params) {
+    Process(std::forward<Arg>(param), std::forward<Args>(params)...);
   }
 
   template<typename Arg>

--- a/include/maidsafe/common/hash/algorithms/hash_algorithm_base.h
+++ b/include/maidsafe/common/hash/algorithms/hash_algorithm_base.h
@@ -117,32 +117,24 @@ class HashAlgorithmBase {
     // There's no need to incude Cereal save/serialize minimal functions since they relate to types
     // which are so basic they shouldn't be using serialisation to hash.
     template <typename T>
-    using HasMemberSave =
-        cereal::traits::has_member_save<typename std::remove_reference<T>::type, Derived>;
+    using HasMemberSave = cereal::traits::has_member_save<Normalize<T>, Derived>;
     template <typename T>
-    using HasNonMemberSave =
-        cereal::traits::has_non_member_save<typename std::remove_reference<T>::type, Derived>;
+    using HasNonMemberSave = cereal::traits::has_non_member_save<Normalize<T>, Derived>;
     template <typename T>
-    using HasMemberSerialize =
-        cereal::traits::has_member_serialize<typename std::remove_reference<T>::type, Derived>;
+    using HasMemberSerialize = cereal::traits::has_member_serialize<Normalize<T>, Derived>;
     template <typename T>
-    using HasNonMemberSerialize =
-        cereal::traits::has_non_member_serialize<typename std::remove_reference<T>::type, Derived>;
+    using HasNonMemberSerialize = cereal::traits::has_non_member_serialize<Normalize<T>, Derived>;
     template <typename T>
-    using HasMemberVersionedSave =
-        cereal::traits::has_member_versioned_save<typename std::remove_reference<T>::type, Derived>;
+    using HasMemberVersionedSave = cereal::traits::has_member_versioned_save<Normalize<T>, Derived>;
     template <typename T>
     using HasNonMemberVersionedSave =
-        cereal::traits::has_non_member_versioned_save<typename std::remove_reference<T>::type,
-                                                      Derived>;
+        cereal::traits::has_non_member_versioned_save<Normalize<T>, Derived>;
     template <typename T>
     using HasMemberVersionedSerialize =
-        cereal::traits::has_member_versioned_serialize<typename std::remove_reference<T>::type,
-                                                       Derived>;
+        cereal::traits::has_member_versioned_serialize<Normalize<T>, Derived>;
     template <typename T>
     using HasNonMemberVersionedSerialize =
-        cereal::traits::has_non_member_versioned_serialize<typename std::remove_reference<T>::type,
-                                                           Derived>;
+        cereal::traits::has_non_member_versioned_serialize<Normalize<T>, Derived>;
 
    public:
     template <typename Type>

--- a/include/maidsafe/common/hash/algorithms/siphash.h
+++ b/include/maidsafe/common/hash/algorithms/siphash.h
@@ -22,6 +22,7 @@
 #include <cstdint>
 
 #include "maidsafe/common/config.h"
+#include "maidsafe/common/types.h"
 #include "maidsafe/common/hash/algorithms/hash_algorithm_base.h"
 
 namespace maidsafe {
@@ -29,16 +30,16 @@ namespace maidsafe {
 class SipHash : public detail::HashAlgorithmBase<SipHash> {
   static const std::size_t kKeySize = 16;
  public:
-  SipHash(const std::array<std::uint8_t, kKeySize>& seed) MAIDSAFE_NOEXCEPT;
+  SipHash(const std::array<byte, kKeySize>& seed) MAIDSAFE_NOEXCEPT;
 
-  void Update(const std::uint8_t* in, std::uint64_t inlen) MAIDSAFE_NOEXCEPT;
+  void Update(const byte* in, std::uint64_t inlen) MAIDSAFE_NOEXCEPT;
 
   /* Finalizes the hash, but does not modify internal state. More data can be
      added and then properly finalized later. */
   std::uint64_t Finalize() const MAIDSAFE_NOEXCEPT;
 
  private:
-  unsigned Compress(const std::uint8_t* in, std::uint64_t inlen) MAIDSAFE_NOEXCEPT;
+  unsigned Compress(const byte* in, std::uint64_t inlen) MAIDSAFE_NOEXCEPT;
 
  private:
   std::uint64_t v0;
@@ -46,7 +47,7 @@ class SipHash : public detail::HashAlgorithmBase<SipHash> {
   std::uint64_t v2;
   std::uint64_t v3;
   unsigned remainder_length_;
-  std::array<std::uint8_t, 8> remainder_;
+  std::array<byte, 8> remainder_;
   std::uint8_t b;
 };
 

--- a/include/maidsafe/common/hash/algorithms/siphash.h
+++ b/include/maidsafe/common/hash/algorithms/siphash.h
@@ -1,0 +1,55 @@
+/*  Copyright 2014 MaidSafe.net limited
+
+    This MaidSafe Software is licensed to you under (1) the MaidSafe.net Commercial License,
+    version 1.0 or later, or (2) The General Public License (GPL), version 3, depending on which
+    licence you accepted on initial access to the Software (the "Licences").
+
+    By contributing code to the MaidSafe Software, or to this project generally, you agree to be
+    bound by the terms of the MaidSafe Contributor Agreement, version 1.0, found in the root
+    directory of this project at LICENSE, COPYING and CONTRIBUTOR respectively and also
+    available at: http://www.maidsafe.net/licenses
+
+    Unless required by applicable law or agreed to in writing, the MaidSafe Software distributed
+    under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+    OF ANY KIND, either express or implied.
+
+    See the Licences for the specific language governing permissions and limitations relating to
+    use of the MaidSafe Software.                                                                 */
+#ifndef MAIDSAFE_COMMON_HASH_ALGORITHMS_SIPHASH_H_
+#define MAIDSAFE_COMMON_HASH_ALGORITHMS_SIPHASH_H_
+
+#include <array>
+#include <cstdint>
+
+#include "maidsafe/common/config.h"
+#include "maidsafe/common/hash/algorithms/hash_algorithm_base.h"
+
+namespace maidsafe {
+
+class SipHash : public detail::HashAlgorithmBase<SipHash> {
+  static const std::size_t kKeySize = 16;
+ public:
+  SipHash(const std::array<std::uint8_t, kKeySize>& seed) MAIDSAFE_NOEXCEPT;
+
+  void Update(const std::uint8_t* in, std::uint64_t inlen) MAIDSAFE_NOEXCEPT;
+
+  /* Finalizes the hash, but does not modify internal state. More data can be
+     added and then properly finalized later. */
+  std::uint64_t Finalize() const MAIDSAFE_NOEXCEPT;
+
+ private:
+  unsigned Compress(const std::uint8_t* in, std::uint64_t inlen) MAIDSAFE_NOEXCEPT;
+
+ private:
+  std::uint64_t v0;
+  std::uint64_t v1;
+  std::uint64_t v2;
+  std::uint64_t v3;
+  unsigned remainder_length_;
+  std::array<std::uint8_t, 8> remainder_;
+  std::uint8_t b;
+};
+
+}  // namespace maidsafe
+
+#endif  // MAIDSAFE_COMMON_HASH_ALGORITHMS_SIPHASH_H_

--- a/include/maidsafe/common/hash/hash_algorithms.h
+++ b/include/maidsafe/common/hash/hash_algorithms.h
@@ -1,0 +1,24 @@
+/*  Copyright 2014 MaidSafe.net limited
+
+    This MaidSafe Software is licensed to you under (1) the MaidSafe.net Commercial License,
+    version 1.0 or later, or (2) The General Public License (GPL), version 3, depending on which
+    licence you accepted on initial access to the Software (the "Licences").
+
+    By contributing code to the MaidSafe Software, or to this project generally, you agree to be
+    bound by the terms of the MaidSafe Contributor Agreement, version 1.0, found in the root
+    directory of this project at LICENSE, COPYING and CONTRIBUTOR respectively and also
+    available at: http://www.maidsafe.net/licenses
+
+    Unless required by applicable law or agreed to in writing, the MaidSafe Software distributed
+    under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+    OF ANY KIND, either express or implied.
+
+    See the Licences for the specific language governing permissions and limitations relating to
+    use of the MaidSafe Software.                                                                 */
+#ifndef MAIDSAFE_COMMON_HASH_HASH_ALGORITHMS_H_
+#define MAIDSAFE_COMMON_HASH_HASH_ALGORITHMS_H_
+
+#include "maidsafe/common/hash/algorithms/hash_algorithm_base.h"
+#include "maidsafe/common/hash/algorithms/siphash.h"
+
+#endif  // MAIDSAFE_COMMON_HASH_HASH_ALGORITHMS_H_

--- a/include/maidsafe/common/hash/hash_array.h
+++ b/include/maidsafe/common/hash/hash_array.h
@@ -1,0 +1,33 @@
+/*  Copyright 2014 MaidSafe.net limited
+
+    This MaidSafe Software is licensed to you under (1) the MaidSafe.net Commercial License,
+    version 1.0 or later, or (2) The General Public License (GPL), version 3, depending on which
+    licence you accepted on initial access to the Software (the "Licences").
+
+    By contributing code to the MaidSafe Software, or to this project generally, you agree to be
+    bound by the terms of the MaidSafe Contributor Agreement, version 1.0, found in the root
+    directory of this project at LICENSE, COPYING and CONTRIBUTOR respectively and also
+    available at: http://www.maidsafe.net/licenses
+
+    Unless required by applicable law or agreed to in writing, the MaidSafe Software distributed
+    under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+    OF ANY KIND, either express or implied.
+
+    See the Licences for the specific language governing permissions and limitations relating to
+    use of the MaidSafe Software.                                                                 */
+#ifndef MAIDSAFE_COMMON_HASH_HASH_ARRAY_H_
+#define MAIDSAFE_COMMON_HASH_HASH_ARRAY_H_
+
+#include <array>
+#include <type_traits>
+
+#include "maidsafe/common/hash/hash_data_range.h"
+
+namespace maidsafe {
+
+template<typename Type, std::size_t Size>
+struct IsHashableDataRange<std::array<Type, Size>> : std::true_type {};
+
+}  // namespace maidsafe
+
+#endif  // MAIDSAFE_COMMON_HASH_HASH_ARRAY_H_

--- a/include/maidsafe/common/hash/hash_contiguous.h
+++ b/include/maidsafe/common/hash/hash_contiguous.h
@@ -20,6 +20,8 @@
 
 #include <type_traits>
 
+#include "maidsafe/common/types.h"
+
 namespace maidsafe {
 
 // Integral types are hashed directly.
@@ -30,7 +32,7 @@ template<typename HashAlgorithm, typename Contiguous>
 inline
 typename std::enable_if<IsContiguousHashable<Contiguous>::value>::type HashAppend(
     HashAlgorithm& hash, const Contiguous& value) {
-  hash.Update(reinterpret_cast<const std::uint8_t*>(&value), sizeof(value));
+  hash.Update(reinterpret_cast<const byte*>(&value), sizeof(value));
 }
 
 }  // namespace maidsafe

--- a/include/maidsafe/common/hash/hash_contiguous.h
+++ b/include/maidsafe/common/hash/hash_contiguous.h
@@ -1,0 +1,38 @@
+/*  Copyright 2014 MaidSafe.net limited
+
+    This MaidSafe Software is licensed to you under (1) the MaidSafe.net Commercial License,
+    version 1.0 or later, or (2) The General Public License (GPL), version 3, depending on which
+    licence you accepted on initial access to the Software (the "Licences").
+
+    By contributing code to the MaidSafe Software, or to this project generally, you agree to be
+    bound by the terms of the MaidSafe Contributor Agreement, version 1.0, found in the root
+    directory of this project at LICENSE, COPYING and CONTRIBUTOR respectively and also
+    available at: http://www.maidsafe.net/licenses
+
+    Unless required by applicable law or agreed to in writing, the MaidSafe Software distributed
+    under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+    OF ANY KIND, either express or implied.
+
+    See the Licences for the specific language governing permissions and limitations relating to
+    use of the MaidSafe Software.                                                                 */
+#ifndef MAIDSAFE_COMMON_HASH_HASH_CONTIGUOUS_H_
+#define MAIDSAFE_COMMON_HASH_HASH_CONTIGUOUS_H_
+
+#include <type_traits>
+
+namespace maidsafe {
+
+// Integral types are hashed directly.
+template<typename Integral, typename Enable = void>
+struct IsContiguousHashable : std::is_integral<Integral> {};
+
+template<typename HashAlgorithm, typename Contiguous>
+inline
+typename std::enable_if<IsContiguousHashable<Contiguous>::value>::type HashAppend(
+    HashAlgorithm& hash, const Contiguous& value) {
+  hash.Update(reinterpret_cast<const std::uint8_t*>(&value), sizeof(value));
+}
+
+}  // namespace maidsafe
+
+#endif  // MAIDSAFE_COMMON_HASH_HASH_CONTIGUOUS_H_

--- a/include/maidsafe/common/hash/hash_data_range.h
+++ b/include/maidsafe/common/hash/hash_data_range.h
@@ -22,6 +22,7 @@
 
 #include "maidsafe/common/hash/hash_contiguous.h"
 #include "maidsafe/common/hash/hash_range.h"
+#include "maidsafe/common/types.h"
 
 namespace maidsafe {
 
@@ -79,7 +80,7 @@ HashAppend(HashAlgorithm& hash, const HashableDataRange& value) {
   using DataType = typename std::remove_pointer<IteratorType>::type;
 
   hash.Update(
-      reinterpret_cast<const std::uint8_t*>(value.data()),
+      reinterpret_cast<const byte*>(value.data()),
       value.size() * sizeof(DataType));
   hash(value.size());
 }

--- a/include/maidsafe/common/hash/hash_data_range.h
+++ b/include/maidsafe/common/hash/hash_data_range.h
@@ -1,0 +1,89 @@
+/*  Copyright 2014 MaidSafe.net limited
+
+    This MaidSafe Software is licensed to you under (1) the MaidSafe.net Commercial License,
+    version 1.0 or later, or (2) The General Public License (GPL), version 3, depending on which
+    licence you accepted on initial access to the Software (the "Licences").
+
+    By contributing code to the MaidSafe Software, or to this project generally, you agree to be
+    bound by the terms of the MaidSafe Contributor Agreement, version 1.0, found in the root
+    directory of this project at LICENSE, COPYING and CONTRIBUTOR respectively and also
+    available at: http://www.maidsafe.net/licenses
+
+    Unless required by applicable law or agreed to in writing, the MaidSafe Software distributed
+    under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+    OF ANY KIND, either express or implied.
+
+    See the Licences for the specific language governing permissions and limitations relating to
+    use of the MaidSafe Software.                                                                 */
+#ifndef MAIDSAFE_COMMON_HASH_HASH_DATA_RANGE_H_
+#define MAIDSAFE_COMMON_HASH_HASH_DATA_RANGE_H_
+
+#include <type_traits>
+
+#include "maidsafe/common/hash/hash_contiguous.h"
+#include "maidsafe/common/hash/hash_range.h"
+
+namespace maidsafe {
+
+/*
+  Types that are a hashable data range must opt-in to the hashing
+  implementation. Overload the trait
+  template<> IsHashableDataRange<YourType> : std::true_type {};. The type must
+  have a .data() function and a .size() function. If the .data() function
+  does not return a pointer type, then this optimization is never used.
+
+  If the data() function returns a pointer to a type that can be hashed over,
+  then it casts the data() pointer to uint8_t and hashes over the elements
+  directly. Otherwise, it falls back to the default HashableRange behavior.
+*/
+template<typename Type, typename Enable = void>
+struct IsHashableDataRange : std::false_type {};
+
+namespace detail {
+
+template<typename HashableRange>
+using DataType = decltype(std::declval<HashableRange>().data());
+
+template<typename, typename Enable = void>
+struct IsContiguousHashableDataRange : std::false_type {};
+
+// If type.data() returns a pointer to a contiguously hashable array
+template<typename HashableDataRange>
+struct IsContiguousHashableDataRange<
+    HashableDataRange,
+    typename std::enable_if<IsHashableDataRange<HashableDataRange>::value>::type> :
+  std::integral_constant<
+      bool,
+      std::is_pointer<DataType<HashableDataRange>>::value &&
+      IsContiguousHashable<
+          typename std::remove_pointer<DataType<HashableDataRange>>::type>::value> {};
+
+}  // namespace detail
+
+// If .data() function returns elements that cannot be hashed over,
+// fallback to a hashable range
+template<typename HashableDataRange>
+struct IsHashableRange<
+    HashableDataRange,
+    typename std::enable_if<IsHashableDataRange<HashableDataRange>::value>::type> :
+  std::integral_constant<bool, !detail::IsContiguousHashableDataRange<HashableDataRange>::value> {};
+
+
+// Hashes over .data()
+template<typename HashAlgorithm, typename HashableDataRange>
+inline
+typename std::enable_if<detail::IsContiguousHashableDataRange<HashableDataRange>::value>::type
+HashAppend(HashAlgorithm& hash, const HashableDataRange& value) {
+  using IteratorType = detail::DataType<HashableDataRange>;
+  static_assert(std::is_pointer<IteratorType>::value, "expected pointer");
+  using DataType = typename std::remove_pointer<IteratorType>::type;
+
+  hash.Update(
+      reinterpret_cast<const std::uint8_t*>(value.data()),
+      value.size() * sizeof(DataType));
+  hash(value.size());
+}
+
+}  // namespace maidsafe
+
+#endif  // MAIDSAFE_COMMON_HASH_HASH_DATA_RANGE_H_

--- a/include/maidsafe/common/hash/hash_forward_list.h
+++ b/include/maidsafe/common/hash/hash_forward_list.h
@@ -1,0 +1,33 @@
+/*  Copyright 2014 MaidSafe.net limited
+
+    This MaidSafe Software is licensed to you under (1) the MaidSafe.net Commercial License,
+    version 1.0 or later, or (2) The General Public License (GPL), version 3, depending on which
+    licence you accepted on initial access to the Software (the "Licences").
+
+    By contributing code to the MaidSafe Software, or to this project generally, you agree to be
+    bound by the terms of the MaidSafe Contributor Agreement, version 1.0, found in the root
+    directory of this project at LICENSE, COPYING and CONTRIBUTOR respectively and also
+    available at: http://www.maidsafe.net/licenses
+
+    Unless required by applicable law or agreed to in writing, the MaidSafe Software distributed
+    under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+    OF ANY KIND, either express or implied.
+
+    See the Licences for the specific language governing permissions and limitations relating to
+    use of the MaidSafe Software.                                                                 */
+#ifndef MAIDSAFE_COMMON_HASH_HASH_FORWARD_LIST_H_
+#define MAIDSAFE_COMMON_HASH_HASH_FORWARD_LIST_H_
+
+#include <forward_list>
+#include <type_traits>
+
+#include "maidsafe/common/hash/hash_range.h"
+
+namespace maidsafe {
+
+template<typename Type, typename Allocator>
+struct IsHashableRange<std::forward_list<Type, Allocator>> : std::true_type {};
+
+}  // namespace maidsafe
+
+#endif  // MAIDSAFE_COMMON_HASH_HASH_FORWARD_LIST_H_

--- a/include/maidsafe/common/hash/hash_initializer_list.h
+++ b/include/maidsafe/common/hash/hash_initializer_list.h
@@ -1,0 +1,35 @@
+/*  Copyright 2014 MaidSafe.net limited
+
+    This MaidSafe Software is licensed to you under (1) the MaidSafe.net Commercial License,
+    version 1.0 or later, or (2) The General Public License (GPL), version 3, depending on which
+    licence you accepted on initial access to the Software (the "Licences").
+
+    By contributing code to the MaidSafe Software, or to this project generally, you agree to be
+    bound by the terms of the MaidSafe Contributor Agreement, version 1.0, found in the root
+    directory of this project at LICENSE, COPYING and CONTRIBUTOR respectively and also
+    available at: http://www.maidsafe.net/licenses
+
+    Unless required by applicable law or agreed to in writing, the MaidSafe Software distributed
+    under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+    OF ANY KIND, either express or implied.
+
+    See the Licences for the specific language governing permissions and limitations relating to
+    use of the MaidSafe Software.                                                                 */
+
+#ifndef MAIDSAFE_COMMON_HASH_HASH_INITIALIZER_LIST_H_
+#define MAIDSAFE_COMMON_HASH_HASH_INITIALIZER_LIST_H_
+
+#include <initializer_list>
+#include <type_traits>
+
+#include "maidsafe/common/hash/hash_range.h"
+
+namespace maidsafe {
+
+// Only iterate if inner type can NOT be hashed over directly
+template<typename Type>
+struct IsHashableRange<std::initializer_list<Type>> : std::true_type {};
+
+}  // namespace maidsafe
+
+#endif  // MAIDSAFE_COMMON_HASH_HASH_INITIALIZER_LIST_H_

--- a/include/maidsafe/common/hash/hash_iterator_range.h
+++ b/include/maidsafe/common/hash/hash_iterator_range.h
@@ -1,0 +1,42 @@
+/*  Copyright 2014 MaidSafe.net limited
+
+    This MaidSafe Software is licensed to you under (1) the MaidSafe.net Commercial License,
+    version 1.0 or later, or (2) The General Public License (GPL), version 3, depending on which
+    licence you accepted on initial access to the Software (the "Licences").
+
+    By contributing code to the MaidSafe Software, or to this project generally, you agree to be
+    bound by the terms of the MaidSafe Contributor Agreement, version 1.0, found in the root
+    directory of this project at LICENSE, COPYING and CONTRIBUTOR respectively and also
+    available at: http://www.maidsafe.net/licenses
+
+    Unless required by applicable law or agreed to in writing, the MaidSafe Software distributed
+    under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+    OF ANY KIND, either express or implied.
+
+    See the Licences for the specific language governing permissions and limitations relating to
+    use of the MaidSafe Software.                                                                 */
+#ifndef MAIDSAFE_COMMON_HASH_HASH_ITERATOR_RANGE_H_
+#define MAIDSAFE_COMMON_HASH_HASH_ITERATOR_RANGE_H_
+
+#include <type_traits>
+
+#include "boost/range/iterator_range.hpp"
+
+#include "maidsafe/common/hash/hash_range.h"
+
+namespace maidsafe {
+
+namespace detail {
+  struct IsIteratorRange {
+    template<typename Iterator>
+    void operator()(const boost::iterator_range<Iterator>&);
+  };
+}
+
+template<typename Range>
+struct IsHashableRange<Range, typename std::result_of<detail::IsIteratorRange(Range)>::type>
+  : std::true_type {};
+
+}  // namespace maidsafe
+
+#endif  // MAIDSAFE_COMMON_HASH_HASH_ITERATOR_RANGE_H_

--- a/include/maidsafe/common/hash/hash_list.h
+++ b/include/maidsafe/common/hash/hash_list.h
@@ -1,0 +1,33 @@
+/*  Copyright 2014 MaidSafe.net limited
+
+    This MaidSafe Software is licensed to you under (1) the MaidSafe.net Commercial License,
+    version 1.0 or later, or (2) The General Public License (GPL), version 3, depending on which
+    licence you accepted on initial access to the Software (the "Licences").
+
+    By contributing code to the MaidSafe Software, or to this project generally, you agree to be
+    bound by the terms of the MaidSafe Contributor Agreement, version 1.0, found in the root
+    directory of this project at LICENSE, COPYING and CONTRIBUTOR respectively and also
+    available at: http://www.maidsafe.net/licenses
+
+    Unless required by applicable law or agreed to in writing, the MaidSafe Software distributed
+    under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+    OF ANY KIND, either express or implied.
+
+    See the Licences for the specific language governing permissions and limitations relating to
+    use of the MaidSafe Software.                                                                 */
+#ifndef MAIDSAFE_COMMON_HASH_HASH_LIST_H_
+#define MAIDSAFE_COMMON_HASH_HASH_LIST_H_
+
+#include <list>
+#include <type_traits>
+
+#include "maidsafe/common/hash/hash_range.h"
+
+namespace maidsafe {
+
+template<typename Type, typename Allocator>
+struct IsHashableRange<std::list<Type, Allocator>> : std::true_type {};
+
+}  // namespace maidsafe
+
+#endif  // MAIDSAFE_COMMON_HASH_HASH_LIST_H_

--- a/include/maidsafe/common/hash/hash_map.h
+++ b/include/maidsafe/common/hash/hash_map.h
@@ -1,0 +1,33 @@
+/*  Copyright 2014 MaidSafe.net limited
+
+    This MaidSafe Software is licensed to you under (1) the MaidSafe.net Commercial License,
+    version 1.0 or later, or (2) The General Public License (GPL), version 3, depending on which
+    licence you accepted on initial access to the Software (the "Licences").
+
+    By contributing code to the MaidSafe Software, or to this project generally, you agree to be
+    bound by the terms of the MaidSafe Contributor Agreement, version 1.0, found in the root
+    directory of this project at LICENSE, COPYING and CONTRIBUTOR respectively and also
+    available at: http://www.maidsafe.net/licenses
+
+    Unless required by applicable law or agreed to in writing, the MaidSafe Software distributed
+    under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+    OF ANY KIND, either express or implied.
+
+    See the Licences for the specific language governing permissions and limitations relating to
+    use of the MaidSafe Software.                                                                 */
+#ifndef MAIDSAFE_COMMON_HASH_HASH_MAP_H_
+#define MAIDSAFE_COMMON_HASH_HASH_MAP_H_
+
+#include <map>
+#include <type_traits>
+
+#include "maidsafe/common/hash/hash_range.h"
+
+namespace maidsafe {
+
+template<typename Key, typename Value, typename Compare, typename Allocator>
+struct IsHashableRange<std::map<Key, Value, Compare, Allocator>> : std::true_type {};
+
+}  // namespace maidsafe
+
+#endif  // MAIDSAFE_COMMON_HASH_HASH_MAP_H_

--- a/include/maidsafe/common/hash/hash_numeric.h
+++ b/include/maidsafe/common/hash/hash_numeric.h
@@ -21,6 +21,7 @@
 #include <type_traits>
 
 #include "maidsafe/common/hash/hash_contiguous.h"
+#include "maidsafe/common/types.h"
 
 namespace maidsafe {
 
@@ -46,7 +47,7 @@ typename std::enable_if<std::is_floating_point<FloatType>::value>::type HashAppe
 #pragma GCC diagnostic pop
 #endif
 
-  hash.Update(reinterpret_cast<const std::uint8_t*>(&value), sizeof(value));
+  hash.Update(reinterpret_cast<const byte*>(&value), sizeof(value));
 }
 
 }  // namespace maidsafe

--- a/include/maidsafe/common/hash/hash_numeric.h
+++ b/include/maidsafe/common/hash/hash_numeric.h
@@ -1,0 +1,54 @@
+/*  Copyright 2014 MaidSafe.net limited
+
+    This MaidSafe Software is licensed to you under (1) the MaidSafe.net Commercial License,
+    version 1.0 or later, or (2) The General Public License (GPL), version 3, depending on which
+    licence you accepted on initial access to the Software (the "Licences").
+
+    By contributing code to the MaidSafe Software, or to this project generally, you agree to be
+    bound by the terms of the MaidSafe Contributor Agreement, version 1.0, found in the root
+    directory of this project at LICENSE, COPYING and CONTRIBUTOR respectively and also
+    available at: http://www.maidsafe.net/licenses
+
+    Unless required by applicable law or agreed to in writing, the MaidSafe Software distributed
+    under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+    OF ANY KIND, either express or implied.
+
+    See the Licences for the specific language governing permissions and limitations relating to
+    use of the MaidSafe Software.                                                                 */
+#ifndef MAIDSAFE_COMMON_HASH_HASH_NUMERIC_H_
+#define MAIDSAFE_COMMON_HASH_HASH_NUMERIC_H_
+
+#include <type_traits>
+
+#include "maidsafe/common/hash/hash_contiguous.h"
+
+namespace maidsafe {
+
+//
+// Integral types default to IsContiguousHashable
+//
+
+template<typename HashAlgorithm, typename FloatType>
+typename std::enable_if<std::is_floating_point<FloatType>::value>::type HashAppend(
+    HashAlgorithm& hash, FloatType value) {
+
+// Yes, we intend to compare exactly 0. All other values are not _exactly_ 0
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wfloat-equal"
+#endif
+
+  if (value == 0.f) {
+    value = 0.f;  // normalize -0 and 0
+  }
+
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
+
+  hash.Update(reinterpret_cast<const std::uint8_t*>(&value), sizeof(value));
+}
+
+}  // namespace maidsafe
+
+#endif  // MAIDSAFE_COMMON_HASH_HASH_NUMERIC_H_

--- a/include/maidsafe/common/hash/hash_pair.h
+++ b/include/maidsafe/common/hash/hash_pair.h
@@ -1,0 +1,48 @@
+/*  Copyright 2014 MaidSafe.net limited
+
+    This MaidSafe Software is licensed to you under (1) the MaidSafe.net Commercial License,
+    version 1.0 or later, or (2) The General Public License (GPL), version 3, depending on which
+    licence you accepted on initial access to the Software (the "Licences").
+
+    By contributing code to the MaidSafe Software, or to this project generally, you agree to be
+    bound by the terms of the MaidSafe Contributor Agreement, version 1.0, found in the root
+    directory of this project at LICENSE, COPYING and CONTRIBUTOR respectively and also
+    available at: http://www.maidsafe.net/licenses
+
+    Unless required by applicable law or agreed to in writing, the MaidSafe Software distributed
+    under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+    OF ANY KIND, either express or implied.
+
+    See the Licences for the specific language governing permissions and limitations relating to
+    use of the MaidSafe Software.                                                                 */
+#ifndef MAIDSAFE_COMMON_HASH_HASH_PAIR_H_
+#define MAIDSAFE_COMMON_HASH_HASH_PAIR_H_
+
+#include <type_traits>
+#include <utility>
+
+#include "maidsafe/common/hash/hash_contiguous.h"
+
+namespace maidsafe {
+
+// If both elements can be "hashed over", and there is no padding
+template<typename First, typename Second>
+struct IsContiguousHashable<std::pair<First, Second>>
+  : std::integral_constant<
+      bool,
+      IsContiguousHashable<First>::value &&
+      IsContiguousHashable<Second>::value &&
+      sizeof(std::pair<First, Second>) == sizeof(First) + sizeof(Second)> {};
+
+
+// This is simple, avoid bringing in cereal headers. Invoked when pair has
+// padding or internal types cannot be hashed over directly.
+template<typename HashAlgorithm, typename First, typename Second>
+typename std::enable_if<!IsContiguousHashable<std::pair<First, Second>>::value>::type HashAppend(
+    HashAlgorithm& hash, const std::pair<First, Second>& value) {
+  hash(value.first, value.second);
+}
+
+}  // namespace maidsafe
+
+#endif  // MAIDSAFE_COMMON_HASH_HASH_PAIR_H_

--- a/include/maidsafe/common/hash/hash_range.h
+++ b/include/maidsafe/common/hash/hash_range.h
@@ -110,7 +110,7 @@ template <typename HashAlgorithm, typename HashableRange>
 inline detail::EnableBasicRange<HashableRange> HashAppend(HashAlgorithm& hash,
                                                           HashableRange&& value) {
   std::size_t count = 0;
-  for (const auto& one_value : value) {
+  for (auto& one_value : value) {
     hash(one_value);
     ++count;
   }
@@ -123,7 +123,7 @@ inline detail::EnableBasicRange<HashableRange> HashAppend(HashAlgorithm& hash,
 template <typename HashAlgorithm, typename HashableRange>
 inline detail::EnableRandomRange<HashableRange> HashAppend(HashAlgorithm& hash,
                                                            HashableRange&& value) {
-  for (const auto& one_value : value) {
+  for (auto& one_value : value) {
     hash(one_value);
   }
 

--- a/include/maidsafe/common/hash/hash_range.h
+++ b/include/maidsafe/common/hash/hash_range.h
@@ -22,6 +22,7 @@
 #include <type_traits>
 
 #include "maidsafe/common/hash/hash_contiguous.h"
+#include "maidsafe/common/types.h"
 
 namespace maidsafe {
 
@@ -145,7 +146,7 @@ inline detail::EnableContinousRange<HashableRange> HashAppend(
 
   const auto size = std::distance(std::begin(value), std::end(value));
   hash.Update(
-      reinterpret_cast<const std::uint8_t*>(std::begin(value)),
+      reinterpret_cast<const byte*>(std::begin(value)),
       size * sizeof(ContainedType));
 
   // in case iterable is empty, make some noise

--- a/include/maidsafe/common/hash/hash_range.h
+++ b/include/maidsafe/common/hash/hash_range.h
@@ -1,0 +1,157 @@
+/*  Copyright 2014 MaidSafe.net limited
+
+    This MaidSafe Software is licensed to you under (1) the MaidSafe.net Commercial License,
+    version 1.0 or later, or (2) The General Public License (GPL), version 3, depending on which
+    licence you accepted on initial access to the Software (the "Licences").
+
+    By contributing code to the MaidSafe Software, or to this project generally, you agree to be
+    bound by the terms of the MaidSafe Contributor Agreement, version 1.0, found in the root
+    directory of this project at LICENSE, COPYING and CONTRIBUTOR respectively and also
+    available at: http://www.maidsafe.net/licenses
+
+    Unless required by applicable law or agreed to in writing, the MaidSafe Software distributed
+    under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+    OF ANY KIND, either express or implied.
+
+    See the Licences for the specific language governing permissions and limitations relating to
+    use of the MaidSafe Software.                                                                 */
+#ifndef MAIDSAFE_COMMON_HASH_HASH_RANGE_H_
+#define MAIDSAFE_COMMON_HASH_HASH_RANGE_H_
+
+#include <iterator>
+#include <type_traits>
+
+#include "maidsafe/common/hash/hash_contiguous.h"
+
+namespace maidsafe {
+
+/*
+  Types that are a hashable range must opt-in to the default hashing
+  implementation. Overload the trait
+  template<> IsHashableRange<YourType> : std::true_type {};. The type must
+  have a std::begin and std::end available for it.
+
+  If a type is marked as a hashable range, it will use std::begin and std::end
+  to iterate + hash over the elements, and then will hash the size of the
+  iteration so that empty ranges still change the hash value. The following
+  optimizations are performed:
+    (1) If std::begin returns a pointer to a type that IsContiguousHashable,
+        the pointer is cast to uint8_t, and all the elements are hashed in one
+        call to the hash function.
+    (2) If not (1), but std::begin returns a random access iterator, a count is
+        not kept while iterating, and is computed at the end.
+    (3) If not (1) or (2), then a count is kept while iterating. This way
+        std::list is still a O(n) operation to hash.
+*/
+template<typename Type, typename Enable = void>
+struct IsHashableRange : std::is_array<Type> {};
+
+namespace detail {
+
+template<typename HashableRange>
+using IteratorType = decltype(std::begin(std::declval<HashableRange>()));
+
+// Remove qualifiers when looking up the user defined trait "IsHashableRange"
+template<typename HashableRange>
+using NormalizeRange =
+  typename std::remove_cv<typename std::remove_reference<HashableRange>::type>::type;
+
+
+template<typename, typename Enable = void>
+struct IsRandomHashableRange : std::false_type {};
+
+// If type declared as iterable and has a random access iterator
+template<typename HashableRange>
+struct IsRandomHashableRange<
+    HashableRange,
+    typename std::enable_if<IsHashableRange<NormalizeRange<HashableRange>>::value>::type> :
+  std::is_same<
+    std::random_access_iterator_tag,
+    typename std::iterator_traits<
+      IteratorType<HashableRange>>::iterator_category> {};
+
+
+template<typename, typename Enable = void>
+struct IsContiguousHashableRange : std::false_type {};
+
+// If type declared as iterable has a pointer iterator and
+// contiguous hashable elements
+template<typename HashableRange>
+struct IsContiguousHashableRange<
+    HashableRange,
+    typename std::enable_if<IsRandomHashableRange<HashableRange>::value>::type> :
+  std::integral_constant<
+      bool,
+      std::is_pointer<IteratorType<HashableRange>>::value &&
+      IsContiguousHashable<
+          typename std::remove_pointer<IteratorType<HashableRange>>::type>::value> {};
+
+
+// Enable Scenario 3
+template<typename HashableRange>
+using EnableBasicRange =
+  typename std::enable_if<
+    IsHashableRange<NormalizeRange<HashableRange>>::value &&
+    !IsRandomHashableRange<HashableRange>::value>::type;
+
+// Enable Scenario 2
+template<typename HashableRange>
+using EnableRandomRange =
+  typename std::enable_if<
+    IsRandomHashableRange<HashableRange>::value &&
+    !IsContiguousHashableRange<HashableRange>::value>::type;
+
+// Enable Scenario 1
+template<typename HashableRange>
+using EnableContinousRange =
+  typename std::enable_if<IsContiguousHashableRange<HashableRange>::value>::type;
+}  // namespace detail
+
+
+// HashableRange with non-random access iterators
+template<typename HashAlgorithm, typename HashableRange>
+inline detail::EnableBasicRange<HashableRange> HashAppend(
+    HashAlgorithm& hash, HashableRange&& value) {
+
+  std::size_t count = 0;
+  for (auto& one_value : value) {
+    hash(one_value);
+    ++count;
+  }
+
+  // in case iterable is empty, make some noise
+  hash(count);
+}
+
+// HashableRange with random access iterators, but not continously hashable data
+template<typename HashAlgorithm, typename HashableRange>
+inline detail::EnableRandomRange<HashableRange> HashAppend(
+    HashAlgorithm& hash, HashableRange&& value) {
+  for (auto& one_value : value) {
+    hash(one_value);
+  }
+
+  // in case iterable is empty, make some noise
+  hash(std::distance(std::begin(value), std::end(value)));
+}
+
+// HashableRange with data that can be continuously hashed over
+template<typename HashAlgorithm, typename HashableRange>
+inline detail::EnableContinousRange<HashableRange> HashAppend(
+    HashAlgorithm& hash, HashableRange&& value) {
+  using IteratorType = detail::IteratorType<HashableRange>;
+  static_assert(std::is_pointer<IteratorType>::value, "bug in traits");
+  using ContainedType = typename std::remove_pointer<IteratorType>::type;
+
+  const auto size = std::distance(std::begin(value), std::end(value));
+  hash.Update(
+      reinterpret_cast<const std::uint8_t*>(std::begin(value)),
+      size * sizeof(ContainedType));
+
+  // in case iterable is empty, make some noise
+  hash(size);
+}
+
+}  // namespace maidsafe
+
+#endif  // MAIDSAFE_COMMON_HASH_HASH_RANGE_H_

--- a/include/maidsafe/common/hash/hash_set.h
+++ b/include/maidsafe/common/hash/hash_set.h
@@ -1,0 +1,33 @@
+/*  Copyright 2014 MaidSafe.net limited
+
+    This MaidSafe Software is licensed to you under (1) the MaidSafe.net Commercial License,
+    version 1.0 or later, or (2) The General Public License (GPL), version 3, depending on which
+    licence you accepted on initial access to the Software (the "Licences").
+
+    By contributing code to the MaidSafe Software, or to this project generally, you agree to be
+    bound by the terms of the MaidSafe Contributor Agreement, version 1.0, found in the root
+    directory of this project at LICENSE, COPYING and CONTRIBUTOR respectively and also
+    available at: http://www.maidsafe.net/licenses
+
+    Unless required by applicable law or agreed to in writing, the MaidSafe Software distributed
+    under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+    OF ANY KIND, either express or implied.
+
+    See the Licences for the specific language governing permissions and limitations relating to
+    use of the MaidSafe Software.                                                                 */
+#ifndef MAIDSAFE_COMMON_HASH_HASH_SET_H_
+#define MAIDSAFE_COMMON_HASH_HASH_SET_H_
+
+#include <set>
+#include <type_traits>
+
+#include "maidsafe/common/hash/hash_range.h"
+
+namespace maidsafe {
+
+template<typename Key, typename Compare, typename Allocator>
+struct IsHashableRange<std::set<Key, Compare, Allocator>> : std::true_type {};
+
+}  // namespace maidsafe
+
+#endif  // MAIDSAFE_COMMON_HASH_HASH_SET_H_

--- a/include/maidsafe/common/hash/hash_string.h
+++ b/include/maidsafe/common/hash/hash_string.h
@@ -1,0 +1,33 @@
+/*  Copyright 2014 MaidSafe.net limited
+
+    This MaidSafe Software is licensed to you under (1) the MaidSafe.net Commercial License,
+    version 1.0 or later, or (2) The General Public License (GPL), version 3, depending on which
+    licence you accepted on initial access to the Software (the "Licences").
+
+    By contributing code to the MaidSafe Software, or to this project generally, you agree to be
+    bound by the terms of the MaidSafe Contributor Agreement, version 1.0, found in the root
+    directory of this project at LICENSE, COPYING and CONTRIBUTOR respectively and also
+    available at: http://www.maidsafe.net/licenses
+
+    Unless required by applicable law or agreed to in writing, the MaidSafe Software distributed
+    under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+    OF ANY KIND, either express or implied.
+
+    See the Licences for the specific language governing permissions and limitations relating to
+    use of the MaidSafe Software.                                                                 */
+#ifndef MAIDSAFE_COMMON_HASH_HASH_STRING_H_
+#define MAIDSAFE_COMMON_HASH_HASH_STRING_H_
+
+#include <string>
+#include <type_traits>
+
+#include "maidsafe/common/hash/hash_data_range.h"
+
+namespace maidsafe {
+
+template<typename CharT, typename Traits, typename Allocator>
+struct IsHashableDataRange<std::basic_string<CharT, Traits, Allocator>> : std::true_type {};
+
+}  // namespace maidsafe
+
+#endif  // MAIDSAFE_COMMON_HASH_HASH_STRING_H_

--- a/include/maidsafe/common/hash/hash_string_ref.h
+++ b/include/maidsafe/common/hash/hash_string_ref.h
@@ -1,0 +1,34 @@
+/*  Copyright 2014 MaidSafe.net limited
+
+    This MaidSafe Software is licensed to you under (1) the MaidSafe.net Commercial License,
+    version 1.0 or later, or (2) The General Public License (GPL), version 3, depending on which
+    licence you accepted on initial access to the Software (the "Licences").
+
+    By contributing code to the MaidSafe Software, or to this project generally, you agree to be
+    bound by the terms of the MaidSafe Contributor Agreement, version 1.0, found in the root
+    directory of this project at LICENSE, COPYING and CONTRIBUTOR respectively and also
+    available at: http://www.maidsafe.net/licenses
+
+    Unless required by applicable law or agreed to in writing, the MaidSafe Software distributed
+    under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+    OF ANY KIND, either express or implied.
+
+    See the Licences for the specific language governing permissions and limitations relating to
+    use of the MaidSafe Software.                                                                 */
+#ifndef MAIDSAFE_COMMON_HASH_HASH_STRING_REF_H_
+#define MAIDSAFE_COMMON_HASH_HASH_STRING_REF_H_
+
+#include <type_traits>
+
+#include "boost/utility/string_ref.hpp"
+
+#include "maidsafe/common/hash/hash_data_range.h"
+
+namespace maidsafe {
+
+template<typename CharT, typename Traits>
+struct IsHashableDataRange<boost::basic_string_ref<CharT, Traits>> : std::true_type {};
+
+}  // namespace maidsafe
+
+#endif  // MAIDSAFE_COMMON_HASH_HASH_STRING_REF_H_

--- a/include/maidsafe/common/hash/hash_tuple.h
+++ b/include/maidsafe/common/hash/hash_tuple.h
@@ -1,0 +1,39 @@
+/*  Copyright 2014 MaidSafe.net limited
+
+    This MaidSafe Software is licensed to you under (1) the MaidSafe.net Commercial License,
+    version 1.0 or later, or (2) The General Public License (GPL), version 3, depending on which
+    licence you accepted on initial access to the Software (the "Licences").
+
+    By contributing code to the MaidSafe Software, or to this project generally, you agree to be
+    bound by the terms of the MaidSafe Contributor Agreement, version 1.0, found in the root
+    directory of this project at LICENSE, COPYING and CONTRIBUTOR respectively and also
+    available at: http://www.maidsafe.net/licenses
+
+    Unless required by applicable law or agreed to in writing, the MaidSafe Software distributed
+    under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+    OF ANY KIND, either express or implied.
+
+    See the Licences for the specific language governing permissions and limitations relating to
+    use of the MaidSafe Software.                                                                 */
+#ifndef MAIDSAFE_COMMON_HASH_HASH_TUPLE_H_
+#define MAIDSAFE_COMMON_HASH_HASH_TUPLE_H_
+
+#include <functional>
+#include <tuple>
+#include <type_traits>
+
+#include "boost/fusion/adapted/std_tuple.hpp"
+#include "boost/fusion/include/for_each.hpp"
+
+namespace maidsafe {
+
+// Cereal uses NVP, which we don't have support for. This is called
+// if the tuple cannot be hashed over in one shot.
+template<typename HashAlgorithm, typename... Elements>
+void HashAppend(HashAlgorithm& hash, const std::tuple<Elements...>& value) {
+  boost::fusion::for_each(value, std::ref(hash));
+}
+
+}  // namespace maidsafe
+
+#endif  // MAIDSAFE_COMMON_HASH_HASH_TUPLE_H_

--- a/include/maidsafe/common/hash/hash_use_serialize.h
+++ b/include/maidsafe/common/hash/hash_use_serialize.h
@@ -1,0 +1,59 @@
+/*  Copyright 2014 MaidSafe.net limited
+
+    This MaidSafe Software is licensed to you under (1) the MaidSafe.net Commercial License,
+    version 1.0 or later, or (2) The General Public License (GPL), version 3, depending on which
+    licence you accepted on initial access to the Software (the "Licences").
+
+    By contributing code to the MaidSafe Software, or to this project generally, you agree to be
+    bound by the terms of the MaidSafe Contributor Agreement, version 1.0, found in the root
+    directory of this project at LICENSE, COPYING and CONTRIBUTOR respectively and also
+    available at: http://www.maidsafe.net/licenses
+
+    Unless required by applicable law or agreed to in writing, the MaidSafe Software distributed
+    under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+    OF ANY KIND, either express or implied.
+
+    See the Licences for the specific language governing permissions and limitations relating to
+    use of the MaidSafe Software.                                                                 */
+#ifndef MAIDSAFE_COMMON_HASH_HASH_USE_SERIALIZE_H_
+#define MAIDSAFE_COMMON_HASH_HASH_USE_SERIALIZE_H_
+
+#include <type_traits>
+
+#define MAIDSAFE_HASH_AND_CEREAL_CLASS_VERSION(TYPE, VERSION_NUMBER) \
+  CEREAL_CLASS_VERSION(TYPE, VERSION_NUMBER)                         \
+  namespace maidsafe {                                               \
+    template<> struct HashVersion<TYPE> :                            \
+      std::integral_constant<unsigned, VERSION_NUMBER> {};           \
+  }
+
+namespace maidsafe {
+
+/*
+   If you want to use the same "serialize" method that Cereal or
+   boost::serialization uses for hashing, simply add
+   const static bool use_serialize_for_hashing = true; in the declaration of
+   your type. If that isn't possible, overload the trait:
+   template<> struct UseSerializeForHashing<YourType> : std::true_type {};
+*/
+template<typename, typename Enable = void>
+struct UseSerializeForHashing : std::false_type {};
+
+template<typename Type>
+struct UseSerializeForHashing<
+    Type, typename std::enable_if<Type::use_serialize_for_hashing>::type> :
+  std::true_type {};
+
+
+/*
+  If serialize with hashing is used, and versioning is used by the
+  archiving tool, overload this trait to tell the hash algorithms what
+  version to use while hashing. If using Cereal too, use the macro
+  MAIDSAFE_HASH_AND_CEREAL_CLASS_VERSION(type, number)
+*/
+template<typename, typename Enable = void>
+struct HashVersion : std::integral_constant<unsigned, 0> {};
+
+}  // namespace maidsafe
+
+#endif  // MAIDSAFE_COMMON_HASH_HASH_USE_SERIALIZE_H_

--- a/include/maidsafe/common/hash/hash_vector.h
+++ b/include/maidsafe/common/hash/hash_vector.h
@@ -1,0 +1,33 @@
+/*  Copyright 2014 MaidSafe.net limited
+
+    This MaidSafe Software is licensed to you under (1) the MaidSafe.net Commercial License,
+    version 1.0 or later, or (2) The General Public License (GPL), version 3, depending on which
+    licence you accepted on initial access to the Software (the "Licences").
+
+    By contributing code to the MaidSafe Software, or to this project generally, you agree to be
+    bound by the terms of the MaidSafe Contributor Agreement, version 1.0, found in the root
+    directory of this project at LICENSE, COPYING and CONTRIBUTOR respectively and also
+    available at: http://www.maidsafe.net/licenses
+
+    Unless required by applicable law or agreed to in writing, the MaidSafe Software distributed
+    under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+    OF ANY KIND, either express or implied.
+
+    See the Licences for the specific language governing permissions and limitations relating to
+    use of the MaidSafe Software.                                                                 */
+#ifndef MAIDSAFE_COMMON_HASH_HASH_VECTOR_H_
+#define MAIDSAFE_COMMON_HASH_HASH_VECTOR_H_
+
+#include <type_traits>
+#include <vector>
+
+#include "maidsafe/common/hash/hash_data_range.h"
+
+namespace maidsafe {
+
+template<typename Type, typename Allocator>
+struct IsHashableDataRange<std::vector<Type, Allocator>> : std::true_type {};
+
+}  // namespace maidsafe
+
+#endif  // MAIDSAFE_COMMON_HASH_HASH_VECTOR_H_

--- a/include/maidsafe/common/hash/hash_wrappers.h
+++ b/include/maidsafe/common/hash/hash_wrappers.h
@@ -1,0 +1,23 @@
+/*  Copyright 2014 MaidSafe.net limited
+
+    This MaidSafe Software is licensed to you under (1) the MaidSafe.net Commercial License,
+    version 1.0 or later, or (2) The General Public License (GPL), version 3, depending on which
+    licence you accepted on initial access to the Software (the "Licences").
+
+    By contributing code to the MaidSafe Software, or to this project generally, you agree to be
+    bound by the terms of the MaidSafe Contributor Agreement, version 1.0, found in the root
+    directory of this project at LICENSE, COPYING and CONTRIBUTOR respectively and also
+    available at: http://www.maidsafe.net/licenses
+
+    Unless required by applicable law or agreed to in writing, the MaidSafe Software distributed
+    under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+    OF ANY KIND, either express or implied.
+
+    See the Licences for the specific language governing permissions and limitations relating to
+    use of the MaidSafe Software.                                                                 */
+#ifndef MAIDSAFE_COMMON_HASH_HASH_WRAPPERS_H_
+#define MAIDSAFE_COMMON_HASH_HASH_WRAPPERS_H_
+
+#include "maidsafe/common/hash/wrappers/seeded_hash.h"
+
+#endif  // MAIDSAFE_COMMON_HASH_HASH_WRAPPERS_H_

--- a/include/maidsafe/common/hash/wrappers/seeded_hash.h
+++ b/include/maidsafe/common/hash/wrappers/seeded_hash.h
@@ -20,9 +20,8 @@
 #define MAIDSAFE_COMMON_HASH_WRAPPERS_SEEDED_HASH_H_
 
 #include <array>
-#include <cstdint>
 
-#include "maidsafe/common/config.h"
+#include "maidsafe/common/types.h"
 #include "maidsafe/common/crypto.h"
 
 namespace maidsafe {
@@ -43,7 +42,7 @@ class SeededHash {
     return hash.Finalize();
   }
  private:
-  std::array<std::uint8_t, 16> seed_128bit_;
+  std::array<byte, 16> seed_128bit_;
 };
 
 }  // namespace maidsafe

--- a/include/maidsafe/common/hash/wrappers/seeded_hash.h
+++ b/include/maidsafe/common/hash/wrappers/seeded_hash.h
@@ -1,0 +1,50 @@
+/*  Copyright 2014 MaidSafe.net limited
+
+    This MaidSafe Software is licensed to you under (1) the MaidSafe.net Commercial License,
+    version 1.0 or later, or (2) The General Public License (GPL), version 3, depending on which
+    licence you accepted on initial access to the Software (the "Licences").
+
+    By contributing code to the MaidSafe Software, or to this project generally, you agree to be
+    bound by the terms of the MaidSafe Contributor Agreement, version 1.0, found in the root
+    directory of this project at LICENSE, COPYING and CONTRIBUTOR respectively and also
+    available at: http://www.maidsafe.net/licenses
+
+    Unless required by applicable law or agreed to in writing, the MaidSafe Software distributed
+    under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+    OF ANY KIND, either express or implied.
+
+    See the Licences for the specific language governing permissions and limitations relating to
+    use of the MaidSafe Software.                                                                 */
+
+#ifndef MAIDSAFE_COMMON_HASH_WRAPPERS_SEEDED_HASH_H_
+#define MAIDSAFE_COMMON_HASH_WRAPPERS_SEEDED_HASH_H_
+
+#include <array>
+#include <cstdint>
+
+#include "maidsafe/common/config.h"
+#include "maidsafe/common/crypto.h"
+
+namespace maidsafe {
+
+template<typename HashAlgorithm>
+class SeededHash {
+ public:
+  SeededHash() : seed_128bit_() {
+    CryptoPP::RandomNumberGenerator& random = maidsafe::crypto::random_number_generator();
+    random.GenerateBlock(seed_128bit_.data(), seed_128bit_.size());
+  }
+
+  template<typename Type>
+  decltype(std::declval<HashAlgorithm>().Finalize()) operator()(Type&& value) const {
+    HashAlgorithm hash{seed_128bit_};
+    hash(std::forward<Type>(value));
+    return hash.Finalize();
+  }
+ private:
+  std::array<std::uint8_t, 16> seed_128bit_;
+};
+
+}  // namespace maidsafe
+
+#endif  // MAIDSAFE_COMMON_HASH_WRAPPERS_SEEDED_HASH_H_

--- a/include/maidsafe/common/hash/wrappers/seeded_hash.h
+++ b/include/maidsafe/common/hash/wrappers/seeded_hash.h
@@ -35,10 +35,11 @@ class SeededHash {
     random.GenerateBlock(seed_128bit_.data(), seed_128bit_.size());
   }
 
-  template<typename Type>
-  decltype(std::declval<HashAlgorithm>().Finalize()) operator()(Type&& value) const {
+  template<typename Type, typename... Types>
+  decltype(std::declval<HashAlgorithm>().Finalize()) operator()(
+      Type&& value, Types&&... values) const {
     HashAlgorithm hash{seed_128bit_};
-    hash(std::forward<Type>(value));
+    hash(std::forward<Type>(value), std::forward<Types>(values)...);
     return hash.Finalize();
   }
  private:

--- a/src/maidsafe/common/hash/algorithms/siphash.cc
+++ b/src/maidsafe/common/hash/algorithms/siphash.cc
@@ -44,7 +44,6 @@
 #pragma warning (disable: 4127)
 #endif
 
-
 #if defined(ROTL)      || \
     defined(U32TO8_LE) || \
     defined(U64TO8_LE) || \
@@ -53,25 +52,25 @@
 #error Previous definition for these macros not expected
 #endif
 
-#define ROTL(x,b) (uint64_t)( ((x) << (b)) | ( (x) >> (64 - (b))) ) /*NOLINT*/
+#define ROTL(x,b) static_cast<uint64_t>( ((x) << (b)) | ( (x) >> (64 - (b))) ) /*NOLINT*/
 
-#define U32TO8_LE(p, v)                                         \
-  (p)[0] = (uint8_t)((v)      ); (p)[1] = (uint8_t)((v) >>  8); \
-  (p)[2] = (uint8_t)((v) >> 16); (p)[3] = (uint8_t)((v) >> 24);
+#define U32TO8_LE(p, v)                                                               \
+  (p)[0] = static_cast<uint8_t>((v)      ); (p)[1] = static_cast<uint8_t>((v) >>  8); \
+  (p)[2] = static_cast<uint8_t>((v) >> 16); (p)[3] = static_cast<uint8_t>((v) >> 24);
 
-#define U64TO8_LE(p, v)                        \
-  U32TO8_LE((p),     (uint32_t)((v)      ));   \
-  U32TO8_LE((p) + 4, (uint32_t)((v) >> 32));
+#define U64TO8_LE(p, v)                                             \
+  U32TO8_LE((p),     static_cast<uint32_t>((v)      )); /*NOLINT*/  \
+  U32TO8_LE((p) + 4, static_cast<uint32_t>((v) >> 32));
 
-#define U8TO64_LE(p)            \
-  (((uint64_t)((p)[0])      ) | \
-   ((uint64_t)((p)[1]) <<  8) | /*NOLINT*/ \
-   ((uint64_t)((p)[2]) << 16) | /*NOLINT*/ \
-   ((uint64_t)((p)[3]) << 24) | /*NOLINT*/ \
-   ((uint64_t)((p)[4]) << 32) | /*NOLINT*/ \
-   ((uint64_t)((p)[5]) << 40) | /*NOLINT*/ \
-   ((uint64_t)((p)[6]) << 48) | /*NOLINT*/ \
-   ((uint64_t)((p)[7]) << 56))  /*NOLINT*/
+#define U8TO64_LE(p)                                  \
+  ((static_cast<uint64_t>((p)[0])      ) |            \
+   (static_cast<uint64_t>((p)[1]) <<  8) | /*NOLINT*/ \
+   (static_cast<uint64_t>((p)[2]) << 16) | /*NOLINT*/ \
+   (static_cast<uint64_t>((p)[3]) << 24) | /*NOLINT*/ \
+   (static_cast<uint64_t>((p)[4]) << 32) | /*NOLINT*/ \
+   (static_cast<uint64_t>((p)[5]) << 40) | /*NOLINT*/ \
+   (static_cast<uint64_t>((p)[6]) << 48) | /*NOLINT*/ \
+   (static_cast<uint64_t>((p)[7]) << 56))  /*NOLINT*/
 
 #define SIPROUND                                              \
   do {                                                        \

--- a/src/maidsafe/common/hash/algorithms/siphash.cc
+++ b/src/maidsafe/common/hash/algorithms/siphash.cc
@@ -1,0 +1,201 @@
+/*  Copyright 2014 MaidSafe.net limited
+
+    This MaidSafe Software is licensed to you under (1) the MaidSafe.net Commercial License,
+    version 1.0 or later, or (2) The General Public License (GPL), version 3, depending on which
+    licence you accepted on initial access to the Software (the "Licences").
+
+    By contributing code to the MaidSafe Software, or to this project generally, you agree to be
+    bound by the terms of the MaidSafe Contributor Agreement, version 1.0, found in the root
+    directory of this project at LICENSE, COPYING and CONTRIBUTOR respectively and also
+    available at: http://www.maidsafe.net/licenses
+
+    Unless required by applicable law or agreed to in writing, the MaidSafe Software distributed
+    under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+    OF ANY KIND, either express or implied.
+
+    See the Licences for the specific language governing permissions and limitations relating to
+    use of the MaidSafe Software.                                                                 */
+
+/*
+  SipHash reference C implementation
+
+  Copyright (c) 2012-2014 Jean-Philippe Aumasson <jeanphilippe.aumasson@gmail.com>
+  Copyright (c) 2012-2014 Daniel J. Bernstein <djb@cr.yp.to>
+
+  To the extent possible under law, the author(s) have dedicated all copyright
+  and related and neighboring rights to this software to the public domain
+  worldwide. This software is distributed without any warranty.
+  You should have received a copy of the CC0 Public Domain Dedication along with
+  this software. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+*/
+
+// Note: The reference version was modified to separate the finalize stage, allowing
+// for non-contiguous bytes. The original document describing SipHash was used to
+// ensure accuracy.
+
+#include "maidsafe/common/hash/algorithms/siphash.h"
+
+#include <algorithm>
+#include <cstring>
+
+// Visual studio warns about the do {} while (0) loop in the macro from SipHash.
+// Only change if you are confident in your abilities ...
+#ifdef _MSC_VER
+#pragma warning (disable: 4127)
+#endif
+
+
+#if defined(ROTL)      || \
+    defined(U32TO8_LE) || \
+    defined(U64TO8_LE) || \
+    defined(U8TO64_LE) || \
+    defined(SIPROUND)
+#error Previous definition for these macros not expected
+#endif
+
+#define ROTL(x,b) (uint64_t)( ((x) << (b)) | ( (x) >> (64 - (b))) ) /*NOLINT*/
+
+#define U32TO8_LE(p, v)                                         \
+  (p)[0] = (uint8_t)((v)      ); (p)[1] = (uint8_t)((v) >>  8); \
+  (p)[2] = (uint8_t)((v) >> 16); (p)[3] = (uint8_t)((v) >> 24);
+
+#define U64TO8_LE(p, v)                        \
+  U32TO8_LE((p),     (uint32_t)((v)      ));   \
+  U32TO8_LE((p) + 4, (uint32_t)((v) >> 32));
+
+#define U8TO64_LE(p)            \
+  (((uint64_t)((p)[0])      ) | \
+   ((uint64_t)((p)[1]) <<  8) | /*NOLINT*/ \
+   ((uint64_t)((p)[2]) << 16) | /*NOLINT*/ \
+   ((uint64_t)((p)[3]) << 24) | /*NOLINT*/ \
+   ((uint64_t)((p)[4]) << 32) | /*NOLINT*/ \
+   ((uint64_t)((p)[5]) << 40) | /*NOLINT*/ \
+   ((uint64_t)((p)[6]) << 48) | /*NOLINT*/ \
+   ((uint64_t)((p)[7]) << 56))  /*NOLINT*/
+
+#define SIPROUND                                              \
+  do {                                                        \
+    v0 += v1; v1 = ROTL(v1, 13); v1 ^= v0; v0 = ROTL(v0, 32); \
+    v2 += v3; v3 = ROTL(v3, 16); v3 ^= v2;                    \
+    v0 += v3; v3 = ROTL(v3, 21); v3 ^= v0;                    \
+    v2 += v1; v1 = ROTL(v1, 17); v1 ^= v2; v2 = ROTL(v2, 32); \
+  } while (0)
+
+namespace maidsafe {
+namespace {
+
+/* default: SipHash-2-4 */
+const unsigned cRounds = 2;
+const unsigned dRounds = 4;
+
+std::uint64_t FinalizeInternal(
+    std::uint64_t v0,
+    std::uint64_t v1,
+    std::uint64_t v2,
+    std::uint64_t v3,
+    std::uint8_t b_in,
+    const std::uint8_t* in,
+    unsigned inlen) MAIDSAFE_NOEXCEPT {
+  assert(inlen <= 8);
+
+  //
+  // Compress remainder bytes
+  //
+  std::uint64_t b = (static_cast<std::uint64_t>(b_in + inlen)) << 56;
+
+  switch (inlen & 7) {
+  case 7: b |= static_cast<std::uint64_t>(in[ 6]) << 48;
+  case 6: b |= static_cast<std::uint64_t>(in[ 5]) << 40;
+  case 5: b |= static_cast<std::uint64_t>(in[ 4]) << 32;
+  case 4: b |= static_cast<std::uint64_t>(in[ 3]) << 24;
+  case 3: b |= static_cast<std::uint64_t>(in[ 2]) << 16;
+  case 2: b |= static_cast<std::uint64_t>(in[ 1]) <<  8;
+  case 1: b |= static_cast<std::uint64_t>(in[ 0]); break;
+  case 0: break;
+  }
+
+  v3 ^= b;
+
+  for (unsigned i = 0; i < cRounds; ++i) SIPROUND;
+
+  v0 ^= b;
+
+  //
+  // Finalize
+  //
+  v2 ^= 0xff;
+
+  for (unsigned i = 0; i < dRounds; ++i) SIPROUND;
+
+  return std::uint64_t(v0 ^ v1 ^ v2  ^ v3);
+}
+}  // namespace
+
+SipHash::SipHash(const std::array<std::uint8_t, kKeySize>& seed) MAIDSAFE_NOEXCEPT
+  : /* "somepseudorandomlygeneratedbytes" */
+    v0(0x736f6d6570736575ULL),
+    v1(0x646f72616e646f6dULL),
+    v2(0x6c7967656e657261ULL),
+    v3(0x7465646279746573ULL),
+    remainder_length_(0),
+    remainder_(),
+    b(0) {
+  const std::uint64_t k0 = U8TO64_LE(seed.data());
+  const std::uint64_t k1 = U8TO64_LE(seed.data() + sizeof(k0));
+
+  v3 ^= k1;
+  v2 ^= k0;
+  v1 ^= k1;
+  v0 ^= k0;
+}
+
+unsigned SipHash::Compress(const std::uint8_t* in, std::uint64_t inlen) MAIDSAFE_NOEXCEPT {
+  const uint8_t* const end = in + inlen - (inlen % sizeof(uint64_t));
+  const unsigned left = inlen & 7;
+
+  for (; in != end; in += 8) {
+    const std::uint64_t m = U8TO64_LE(in);
+    v3 ^= m;
+
+    for (unsigned i = 0; i < cRounds; ++i) SIPROUND;
+
+    v0 ^= m;
+  }
+
+  return left;
+}
+
+void SipHash::Update(const std::uint8_t* in, std::uint64_t inlen) MAIDSAFE_NOEXCEPT {
+  assert(remainder_length_ < remainder_.size());
+
+  if (remainder_length_ > 0) {
+    const std::uint64_t copy_length =
+        std::min<std::uint64_t>(inlen, remainder_.size() - remainder_length_);
+
+    std::copy(in, in + copy_length, remainder_.data() + remainder_length_);
+
+    in += copy_length;
+    inlen -= copy_length;
+
+    remainder_length_ = unsigned(remainder_length_ + copy_length);
+    b = std::uint8_t(b + copy_length);
+
+    remainder_length_ = Compress(remainder_.data(), remainder_length_);
+  }
+
+  const unsigned left = Compress(in, inlen);
+
+  assert(remainder_length_ + left < remainder_.size());
+  std::copy(in + (inlen - left), in + inlen, remainder_.data() + remainder_length_);
+
+  remainder_length_ += left;
+  b = std::uint8_t(b + inlen);
+}
+
+std::uint64_t SipHash::Finalize() const MAIDSAFE_NOEXCEPT {
+  // Copy state, so this object isn't actually finalized
+  assert(remainder_length_ <= remainder_.size());
+  return FinalizeInternal(v0, v1, v2, v3, b, remainder_.data(), remainder_length_);
+}
+
+}  // namespace maidsafe

--- a/src/maidsafe/common/hash/algorithms/siphash.cc
+++ b/src/maidsafe/common/hash/algorithms/siphash.cc
@@ -94,7 +94,7 @@ std::uint64_t FinalizeInternal(
     std::uint64_t v2,
     std::uint64_t v3,
     std::uint8_t b_in,
-    const std::uint8_t* in,
+    const byte* in,
     unsigned inlen) MAIDSAFE_NOEXCEPT {
   assert(inlen < 8);
 
@@ -131,7 +131,7 @@ std::uint64_t FinalizeInternal(
 }
 }  // namespace
 
-SipHash::SipHash(const std::array<std::uint8_t, kKeySize>& seed) MAIDSAFE_NOEXCEPT
+SipHash::SipHash(const std::array<byte, kKeySize>& seed) MAIDSAFE_NOEXCEPT
   : /* "somepseudorandomlygeneratedbytes" */
     v0(0x736f6d6570736575ULL),
     v1(0x646f72616e646f6dULL),
@@ -149,7 +149,7 @@ SipHash::SipHash(const std::array<std::uint8_t, kKeySize>& seed) MAIDSAFE_NOEXCE
   v0 ^= k0;
 }
 
-unsigned SipHash::Compress(const std::uint8_t* in, std::uint64_t inlen) MAIDSAFE_NOEXCEPT {
+unsigned SipHash::Compress(const byte* in, std::uint64_t inlen) MAIDSAFE_NOEXCEPT {
   const uint8_t* const end = in + inlen - (inlen % sizeof(uint64_t));
   const unsigned left = inlen & 7;
 
@@ -165,7 +165,7 @@ unsigned SipHash::Compress(const std::uint8_t* in, std::uint64_t inlen) MAIDSAFE
   return left;
 }
 
-void SipHash::Update(const std::uint8_t* in, std::uint64_t inlen) MAIDSAFE_NOEXCEPT {
+void SipHash::Update(const byte* in, std::uint64_t inlen) MAIDSAFE_NOEXCEPT {
   assert(remainder_length_ < remainder_.size());
 
   if (remainder_length_ > 0) {

--- a/src/maidsafe/common/hash/algorithms/siphash.cc
+++ b/src/maidsafe/common/hash/algorithms/siphash.cc
@@ -96,7 +96,7 @@ std::uint64_t FinalizeInternal(
     std::uint8_t b_in,
     const std::uint8_t* in,
     unsigned inlen) MAIDSAFE_NOEXCEPT {
-  assert(inlen <= 8);
+  assert(inlen < 8);
 
   //
   // Compress remainder bytes
@@ -185,6 +185,7 @@ void SipHash::Update(const std::uint8_t* in, std::uint64_t inlen) MAIDSAFE_NOEXC
 
   const unsigned left = Compress(in, inlen);
 
+  assert(left <= inlen);
   assert(remainder_length_ + left < remainder_.size());
   std::copy(in + (inlen - left), in + inlen, remainder_.data() + remainder_length_);
 
@@ -194,7 +195,7 @@ void SipHash::Update(const std::uint8_t* in, std::uint64_t inlen) MAIDSAFE_NOEXC
 
 std::uint64_t SipHash::Finalize() const MAIDSAFE_NOEXCEPT {
   // Copy state, so this object isn't actually finalized
-  assert(remainder_length_ <= remainder_.size());
+  assert(remainder_length_ < remainder_.size());
   return FinalizeInternal(v0, v1, v2, v3, b, remainder_.data(), remainder_length_);
 }
 

--- a/src/maidsafe/common/hash/tests/hash_test.cc
+++ b/src/maidsafe/common/hash/tests/hash_test.cc
@@ -658,6 +658,25 @@ TYPED_TEST(TypedHashTest, BEH_CerealAndHashing) {
   EXPECT_EQ(original_hash, hash(copy));
 }
 
+TYPED_TEST(TypedHashTest, BEH_CustomTypesInContainer) {
+  const maidsafe::SeededHash<maidsafe::SipHash> hash{};
+  TypeParam data[] = {TypeParam{10, 20, 30}, TypeParam{30, 20, 10}};
+  const std::uint64_t reference = hash(data);
+
+  EXPECT_EQ(reference, hash(10, 20, 30, 30, 20, 10, std::size_t(2)));
+  EXPECT_EQ(reference,
+            hash(std::array<TypeParam, 2>{{TypeParam{10, 20, 30}, TypeParam{30, 20, 10}}}));
+  {
+    std::map<int, TypeParam> test_map{{1, TypeParam{10, 20, 30}}, {2, TypeParam{30, 20, 10}}};
+    EXPECT_EQ(reference, hash(test_map | boost::adaptors::map_values));
+  }
+  EXPECT_EQ(reference,
+            hash(std::forward_list<TypeParam>{TypeParam{10, 20, 30}, TypeParam{30, 20, 10}}));
+  EXPECT_EQ(reference, hash(std::list<TypeParam>{TypeParam{10, 20, 30}, TypeParam{30, 20, 10}}));
+  EXPECT_EQ(reference,
+            hash(std::vector<TypeParam>{TypeParam{10, 20, 30}, TypeParam{30, 20, 10}}));
+}
+
 TEST(HashTest, BEH_InHashMap) {
   std::unordered_map<std::pair<std::string, std::string>, int,
                      maidsafe::SeededHash<maidsafe::SipHash>> hash_table;

--- a/src/maidsafe/common/hash/tests/hash_test.cc
+++ b/src/maidsafe/common/hash/tests/hash_test.cc
@@ -146,9 +146,10 @@ namespace test {
 
 TEST(HashTest, BEH_NumericRange) {
   const maidsafe::SeededHash<maidsafe::SipHash> hash{};
-  const int data[] = { 10, 20, 30 };
+  const int data[] = {10, 20, 30};
   const std::uint64_t reference = hash(data);
 
+  EXPECT_EQ(reference, hash(10, 20, 30, std::size_t(3)));
   EXPECT_EQ(reference, hash(std::array<int, 3>({{10, 20, 30}})));
   EXPECT_EQ(
       reference,

--- a/src/maidsafe/common/hash/tests/hash_test.cc
+++ b/src/maidsafe/common/hash/tests/hash_test.cc
@@ -1,0 +1,338 @@
+/*  Copyright 2014 MaidSafe.net limited
+
+    This MaidSafe Software is licensed to you under (1) the MaidSafe.net Commercial License,
+    version 1.0 or later, or (2) The General Public License (GPL), version 3, depending on which
+    licence you accepted on initial access to the Software (the "Licences").
+
+    By contributing code to the MaidSafe Software, or to this project generally, you agree to be
+    bound by the terms of the MaidSafe Contributor Agreement, version 1.0, found in the root
+    directory of this project at LICENSE, COPYING and CONTRIBUTOR respectively and also
+    available at: http://www.maidsafe.net/licenses
+
+    Unless required by applicable law or agreed to in writing, the MaidSafe Software distributed
+    under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+    OF ANY KIND, either express or implied.
+
+    See the Licences for the specific language governing permissions and limitations relating to
+    use of the MaidSafe Software.                                                                 */
+#include <forward_list>
+#include <initializer_list>
+#include <list>
+#include <set>
+#include <sstream>
+#include <string>
+#include <tuple>
+#include <unordered_map>
+#include <vector>
+
+#include "boost/range/adaptor/map.hpp"
+#include "boost/range/iterator_range.hpp"
+#include "boost/utility/string_ref.hpp"
+
+#include "cereal/cereal.hpp"
+#include "cereal/archives/binary.hpp"
+
+#include "maidsafe/common/hash.h"
+#include "maidsafe/common/test.h"
+
+namespace {
+struct IgnoreInternalSerialize {
+  int one, two, three;
+
+  template<typename Archive>
+  void serialize(Archive& archive) {
+    archive(three, two, one);
+  }
+
+  template<typename HashAlgorithm>
+  void HashAppend(HashAlgorithm& hash) const {
+    hash(one, two, three);
+  }
+};
+
+struct UseInternalSerializeWithVersion {
+  const static bool use_serialize_for_hashing = true;  //NOLINT
+  int one, two, three;
+
+  template<typename Archive>
+  void serialize(Archive& archive, const unsigned version) {
+    EXPECT_EQ(0u, version);
+    archive & one & two & three;
+  }
+};
+
+struct UseInternalSerializeWithoutVersion {
+  const static bool use_serialize_for_hashing = true;  //NOLINT
+  int one, two, three;
+
+  template<typename Archive>
+  void serialize(Archive& archive) {
+    archive & one & two & three;
+  }
+};
+
+struct IgnoreExternalSerialize {
+  int one, two, three;
+};
+
+struct UseExternalSerializeWithVersion {
+  const static bool use_serialize_for_hashing = true;  //NOLINT
+  int one, two, three;
+};
+
+struct UseExternalSerializeWithoutVersion {
+  int one, two, three;
+};
+
+template<typename Archive>
+void serialize(Archive& archive, IgnoreExternalSerialize& value) {
+  archive(value.three, value.two, value.one);
+}
+
+template<typename HashAlgorithm>
+void HashAppend(HashAlgorithm& hash, const IgnoreExternalSerialize& value) {
+  hash(value.one, value.two, value.three);
+}
+
+template<typename Archive>
+void serialize(
+    Archive& archive, UseExternalSerializeWithVersion& value, const unsigned version) {
+  EXPECT_EQ(10u, version);
+  archive & value.one & value.two & value.three;
+}
+
+template<typename Archive>
+void serialize(Archive& archive, UseExternalSerializeWithoutVersion& value) {
+  archive & value.one & value.two & value.three;
+}
+
+template<typename CustomType>
+void TestCustomType() {
+  const maidsafe::SeededHash<maidsafe::SipHash> hash{};
+  CustomType original = {-500, 5000, 50000};
+  const std::uint64_t original_hash = hash(original);
+
+  std::string serialized;
+  {
+    std::ostringstream out;
+    {
+      cereal::BinaryOutputArchive archive(out);
+      archive(original);
+    }
+    serialized = out.str();
+  }
+
+  CustomType copy{0, 0, 0};
+  EXPECT_NE(original_hash, hash(copy));
+  {
+    std::istringstream in(serialized);
+    cereal::BinaryInputArchive archive(in);
+    archive(copy);
+  }
+  EXPECT_EQ(original_hash, hash(copy));
+}
+
+}  // namespace
+
+MAIDSAFE_HASH_AND_CEREAL_CLASS_VERSION(UseExternalSerializeWithVersion, 10)
+
+namespace maidsafe {
+
+template<>
+struct UseSerializeForHashing<UseExternalSerializeWithoutVersion>
+  : std::true_type {};
+
+namespace test {
+
+TEST(HashTest, BEH_NumericRange) {
+  const maidsafe::SeededHash<maidsafe::SipHash> hash{};
+  const int data[] = { 10, 20, 30 };
+  const std::uint64_t reference = hash(data);
+
+  EXPECT_EQ(reference, hash(std::array<int, 3>({{10, 20, 30}})));
+  EXPECT_EQ(
+      reference,
+      hash(std::map<int, int>({{1, 10}, {2, 20}, {3, 30}}) | boost::adaptors::map_values));
+  EXPECT_EQ(reference, hash(std::forward_list<int>({10, 20, 30})));
+  EXPECT_EQ(reference, hash(std::list<int>({10, 20, 30})));
+  EXPECT_EQ(reference, hash(std::initializer_list<int>({10, 20, 30})));
+  EXPECT_EQ(reference, hash(std::set<int>({10, 20, 30})));
+  EXPECT_EQ(reference, hash(std::vector<int>({10, 20, 30})));
+}
+
+TEST(HashTest, BEH_PairVerification) {
+  {
+    maidsafe::SipHash hash1{{{}}};
+    maidsafe::SipHash hash2{{{}}};
+
+    hash1(100, 1000);
+    hash2(std::make_pair(100, 1000));
+
+    EXPECT_EQ(hash1.Finalize(), hash2.Finalize());
+  }
+  {
+    maidsafe::SipHash hash1{{{}}};
+    maidsafe::SipHash hash2{{{}}};
+
+    hash1(boost::string_ref("<-->"), 100.5);
+    hash2(std::make_pair(boost::string_ref("<-->"), 100.5));
+
+    EXPECT_EQ(hash1.Finalize(), hash2.Finalize());
+  }
+}
+
+TEST(HashTest, BEH_PairRange) {
+  const maidsafe::SeededHash<maidsafe::SipHash> hash{};
+  const std::initializer_list<std::pair<int, int>> data = {{3, 10}, {50, 20}, {1000, 30}};
+  const std::uint64_t reference = hash(data);
+
+  EXPECT_EQ(reference, hash(std::forward_list<std::pair<int, int>>(data)));
+  EXPECT_EQ(reference, hash(std::list<std::pair<int, int>>(data)));
+  EXPECT_EQ(reference, hash(std::map<int, int>({{3, 10}, {50, 20}, {1000, 30}})));
+  EXPECT_EQ(reference, hash(std::set<std::pair<int, int>>(data)));
+  EXPECT_EQ(reference, hash(std::vector<std::pair<int, int>>(data)));
+
+  EXPECT_EQ(
+      reference,
+      hash(std::forward_list<std::tuple<int, int>>({
+          std::make_tuple(3, 10), std::make_tuple(50, 20), std::make_tuple(1000, 30) })));
+}
+
+TEST(HashTest, BEH_TupleVerification) {
+  {
+    const maidsafe::SipHash hash1{{{}}};
+    maidsafe::SipHash hash2{{{}}};
+    hash2(std::tuple<>{});
+    EXPECT_EQ(hash1.Finalize(), hash2.Finalize());
+  }
+  {
+    maidsafe::SipHash hash1{{{}}};
+    maidsafe::SipHash hash2{{{}}};
+
+    hash1(100, 1000, 10000);
+    hash2(std::make_tuple(100, 1000, 10000));
+
+    EXPECT_EQ(hash1.Finalize(), hash2.Finalize());
+  }
+  {
+    maidsafe::SipHash hash1{{{}}};
+    maidsafe::SipHash hash2{{{}}};
+
+    hash1(boost::string_ref("<-->"), 100.5, 90000);
+    hash2(std::make_tuple(boost::string_ref("<-->"), 100.5, 90000));
+
+    EXPECT_EQ(hash1.Finalize(), hash2.Finalize());
+  }
+}
+
+TEST(HashTest, BEH_TupleRange) {
+  const maidsafe::SeededHash<maidsafe::SipHash> hash{};
+  const std::initializer_list<std::tuple<int, int, int>> data {
+     std::make_tuple(3, 10, 1000),
+     std::make_tuple(50, 20, 122),
+     std::make_tuple(1000, 30, 33)
+  };
+  const std::uint64_t reference = hash(data);
+
+  EXPECT_EQ(reference, hash(std::forward_list<std::tuple<int, int, int>>(data)));
+  EXPECT_EQ(reference, hash(std::list<std::tuple<int, int, int>>(data)));
+  EXPECT_EQ(reference, hash(std::vector<std::tuple<int, int, int>>(data)));
+}
+
+TEST(HashTest, BEH_FloatRange) {
+  const maidsafe::SeededHash<maidsafe::SipHash> hash{};
+  const std::initializer_list<std::pair<int, float>> data =
+      { {3, 10.4f}, {50, -0.f}, {1000, 30.2f} };
+  const std::uint64_t reference = hash(data);
+
+  EXPECT_EQ(reference, hash(std::forward_list<std::pair<int, float>>(data)));
+  EXPECT_EQ(reference, hash(std::list<std::pair<int, float>>(data)));
+  EXPECT_EQ(reference, hash(std::map<int, float>({{3, 10.4f}, {50, -0.f}, {1000, 30.2f}})));
+  EXPECT_EQ(reference, hash(std::set<std::pair<int, float>>(data)));
+  EXPECT_EQ(reference, hash(std::vector<std::pair<int, float>>(data)));
+
+  // Retry with positive 0
+  EXPECT_EQ(
+      reference,
+      hash(std::vector<std::pair<int, float>>({{3, 10.4f}, {50, 0.f}, {1000, 30.2f}})));
+}
+
+TEST(HashTest, BEH_DoubleRange) {
+  const maidsafe::SeededHash<maidsafe::SipHash> hash{};
+  const std::initializer_list<std::pair<int, double>> data =
+      { {3, 10.4}, {50, -0.f}, {1000, 30.2} };
+  const std::uint64_t reference = hash(data);
+
+  EXPECT_EQ(reference, hash(std::forward_list<std::pair<int, double>>(data)));
+  EXPECT_EQ(reference, hash(std::list<std::pair<int, double>>(data)));
+  EXPECT_EQ(reference, hash(std::map<int, double>({{3, 10.4}, {50, -0.f}, {1000, 30.2}})));
+  EXPECT_EQ(reference, hash(std::set<std::pair<int, double>>(data)));
+  EXPECT_EQ(reference, hash(std::vector<std::pair<int, double>>(data)));
+
+  // Retry with positive 0
+  EXPECT_EQ(
+      reference,
+      hash(std::vector<std::pair<int, double>>({ {3, 10.4}, {50, 0.f}, {1000, 30.2} })));
+}
+
+TEST(HashTest, BEH_StringRange) {
+  const maidsafe::SeededHash<maidsafe::SipHash> hash{};
+  const std::initializer_list<std::string> data = { "string1", "string2", "string3" };
+  const std::uint64_t reference = hash(data);
+
+  EXPECT_EQ(
+      reference,
+      hash(
+          std::map<std::string, int>({{"string1", 10}, {"string2", 20}, {"string3", 30}}) |
+          boost::adaptors::map_keys));
+  EXPECT_EQ(reference, hash(std::forward_list<std::string>(data)));
+  EXPECT_EQ(reference, hash(std::list<std::string>(data)));
+  EXPECT_EQ(reference, hash(std::set<std::string>(data)));
+  EXPECT_EQ(reference, hash(std::vector<std::string>(data)));
+
+  std::vector<boost::string_ref> ref_data = { "string1-", "string2", "string3" };
+  EXPECT_NE(reference, hash(ref_data));
+  ref_data[0].remove_suffix(1);
+  EXPECT_EQ(reference, hash(ref_data));
+}
+
+TEST(HashTest, BEH_PreferHashAppend) {
+  const maidsafe::SeededHash<maidsafe::SipHash> hash{};
+  EXPECT_EQ(
+      hash(UseInternalSerializeWithVersion{10, 20, 30}),
+      hash(IgnoreInternalSerialize{10, 20, 30}));
+  EXPECT_EQ(
+      hash(UseInternalSerializeWithVersion{10, 20, 30}),
+      hash(IgnoreExternalSerialize{10, 20, 30}));
+}
+
+TEST(HashTest, BEH_CerealAndHashing) {
+  TestCustomType<IgnoreInternalSerialize>();
+  TestCustomType<UseInternalSerializeWithVersion>();
+  TestCustomType<UseInternalSerializeWithoutVersion>();
+  TestCustomType<IgnoreExternalSerialize>();
+  TestCustomType<UseExternalSerializeWithVersion>();
+  TestCustomType<UseExternalSerializeWithoutVersion>();
+}
+
+TEST(HashTest, BEH_InHashMap) {
+  std::unordered_map<
+    std::pair<std::string, std::string>,
+    int,
+    maidsafe::SeededHash<maidsafe::SipHash>> hash_table;
+
+  hash_table[{"entry", "one"}] = -1;
+  hash_table[{"entry", "two"}] = 2;
+  hash_table[{"entri", "one"}] = 3;
+
+  const auto value1 = hash_table[{"entry", "one"}];
+  const auto value2 = hash_table[{"entry", "two"}];
+  const auto value3 = hash_table[{"entri", "one"}];
+
+  EXPECT_EQ(-1, value1);
+  EXPECT_EQ(2, value2);
+  EXPECT_EQ(3, value3);
+}
+
+}  // namespace test
+}  // namespace maidsafe

--- a/src/maidsafe/common/hash/tests/siphash_test.cc
+++ b/src/maidsafe/common/hash/tests/siphash_test.cc
@@ -180,21 +180,21 @@ int siphash(uint8_t *out, const uint8_t *in, uint64_t inlen, const uint8_t *k) {
   return 0;
 }
 
-std::array<std::uint8_t, 16> GetRandomSeed() {
-  std::array<std::uint8_t, 16> seed{{}};
+std::array<byte, 16> GetRandomSeed() {
+  std::array<byte, 16> seed{{}};
   CryptoPP::RandomNumberGenerator& random = maidsafe::crypto::random_number_generator();
   random.GenerateBlock(seed.data(), seed.size());
   return seed;
 }
 
 std::uint64_t SiphashReference(
-    const std::array<std::uint8_t, 16>& seed,
+    const std::array<byte, 16>& seed,
     const char* in,
     const std::uint64_t inlen) {
   std::uint64_t out{};
   siphash(
-      reinterpret_cast<std::uint8_t*>(&out),
-      reinterpret_cast<const std::uint8_t*>(in),
+      reinterpret_cast<byte*>(&out),
+      reinterpret_cast<const byte*>(in),
       inlen,
       seed.data());
   return out;
@@ -211,9 +211,9 @@ TEST(SipHash, BEH_FixedString) {
   // Split the string at every possible point
   for (unsigned count = 0; count <= string_size; ++count) {
     maidsafe::SipHash hash(random_seed);
-    hash.Update(reinterpret_cast<const std::uint8_t*>(test_string), count);
+    hash.Update(reinterpret_cast<const byte*>(test_string), count);
     hash.Update(
-        reinterpret_cast<const std::uint8_t*>(test_string) + count, string_size - count);
+        reinterpret_cast<const byte*>(test_string) + count, string_size - count);
     EXPECT_EQ(reference_hash, hash.Finalize()) << "Failed on count " << count;
   }
 
@@ -221,7 +221,7 @@ TEST(SipHash, BEH_FixedString) {
   {
     maidsafe::SipHash hash(random_seed);
     for (unsigned count = 0; count < string_size; ++count) {
-      hash.Update(reinterpret_cast<const std::uint8_t*>(&test_string[count]), 1);
+      hash.Update(reinterpret_cast<const byte*>(&test_string[count]), 1);
     }
     EXPECT_EQ(reference_hash, hash.Finalize());
   }
@@ -236,9 +236,9 @@ TEST(SipHash, BEH_RandomString) {
   // Split the string at every possible point
   for (unsigned count = 0; count <= test_string.size(); ++count) {
     maidsafe::SipHash hash(random_seed);
-    hash.Update(reinterpret_cast<const std::uint8_t*>(test_string.data()), count);
+    hash.Update(reinterpret_cast<const byte*>(test_string.data()), count);
     hash.Update(
-        reinterpret_cast<const std::uint8_t*>(test_string.data()) + count,
+        reinterpret_cast<const byte*>(test_string.data()) + count,
         test_string.size() - count);
     EXPECT_EQ(reference_hash, hash.Finalize()) << "Failed on count " << count;
   }
@@ -247,7 +247,7 @@ TEST(SipHash, BEH_RandomString) {
   {
     maidsafe::SipHash hash(random_seed);
     for (unsigned count = 0; count < test_string.size(); ++count) {
-      hash.Update(reinterpret_cast<const std::uint8_t*>(test_string.data() + count), 1);
+      hash.Update(reinterpret_cast<const byte*>(test_string.data() + count), 1);
     }
     EXPECT_EQ(reference_hash, hash.Finalize());
   }

--- a/src/maidsafe/common/hash/tests/siphash_test.cc
+++ b/src/maidsafe/common/hash/tests/siphash_test.cc
@@ -1,0 +1,257 @@
+/*  Copyright 2014 MaidSafe.net limited
+
+    This MaidSafe Software is licensed to you under (1) the MaidSafe.net Commercial License,
+    version 1.0 or later, or (2) The General Public License (GPL), version 3, depending on which
+    licence you accepted on initial access to the Software (the "Licences").
+
+    By contributing code to the MaidSafe Software, or to this project generally, you agree to be
+    bound by the terms of the MaidSafe Contributor Agreement, version 1.0, found in the root
+    directory of this project at LICENSE, COPYING and CONTRIBUTOR respectively and also
+    available at: http://www.maidsafe.net/licenses
+
+    Unless required by applicable law or agreed to in writing, the MaidSafe Software distributed
+    under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+    OF ANY KIND, either express or implied.
+
+    See the Licences for the specific language governing permissions and limitations relating to
+    use of the MaidSafe Software.                                                                 */
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+
+#include "maidsafe/common/crypto.h"
+#include "maidsafe/common/hash/algorithms/siphash.h"
+#include "maidsafe/common/test.h"
+#include "maidsafe/common/utils.h"
+
+// Visual studio warns about the do {} while (0) loop in the macro from SipHash.
+// Do not change the reference implementation for testing.
+#ifdef _MSC_VER
+#pragma warning (disable: 4127)
+#endif
+
+namespace maidsafe {
+namespace test {
+
+namespace {
+
+//
+// NOTE: The liberal usage of NOLINT was done to perserve the reference
+// SipHash code, even it the change was merely style.
+//
+
+/*
+   SipHash reference C implementation
+
+   Copyright (c) 2012-2014 Jean-Philippe Aumasson <jeanphilippe.aumasson@gmail.com>
+   Copyright (c) 2012-2014 Daniel J. Bernstein <djb@cr.yp.to>
+
+   To the extent possible under law, the author(s) have dedicated all copyright
+   and related and neighboring rights to this software to the public domain
+   worldwide. This software is distributed without any warranty.
+
+   You should have received a copy of the CC0 Public Domain Dedication along with
+   this software. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+/* default: SipHash-2-4 */
+#define cROUNDS 2
+#define dROUNDS 4
+
+#define ROTL(x,b) (uint64_t)( ((x) << (b)) | ( (x) >> (64 - (b))) ) /*NOLINT*/
+
+#define U32TO8_LE(p, v)                                         \
+  (p)[0] = (uint8_t)((v)      ); (p)[1] = (uint8_t)((v) >>  8); \
+  (p)[2] = (uint8_t)((v) >> 16); (p)[3] = (uint8_t)((v) >> 24);
+
+#define U64TO8_LE(p, v)                        \
+  U32TO8_LE((p),     (uint32_t)((v)      ));   \
+  U32TO8_LE((p) + 4, (uint32_t)((v) >> 32));
+
+
+#define U8TO64_LE(p)            \
+  (((uint64_t)((p)[0])      ) | \
+   ((uint64_t)((p)[1]) <<  8) | /*NOLINT*/ \
+   ((uint64_t)((p)[2]) << 16) | /*NOLINT*/ \
+   ((uint64_t)((p)[3]) << 24) | /*NOLINT*/ \
+   ((uint64_t)((p)[4]) << 32) | /*NOLINT*/ \
+   ((uint64_t)((p)[5]) << 40) | /*NOLINT*/ \
+   ((uint64_t)((p)[6]) << 48) | /*NOLINT*/ \
+   ((uint64_t)((p)[7]) << 56))  /*NOLINT*/
+
+#define SIPROUND                                                   \
+  do {                                                             \
+    v0 += v1; v1=ROTL(v1,13); v1 ^= v0; v0=ROTL(v0,32); /*NOLINT*/ \
+    v2 += v3; v3=ROTL(v3,16); v3 ^= v2;                 /*NOLINT*/ \
+    v0 += v3; v3=ROTL(v3,21); v3 ^= v0;                 /*NOLINT*/ \
+    v2 += v1; v1=ROTL(v1,17); v1 ^= v2; v2=ROTL(v2,32); /*NOLINT*/ \
+  } while(0)                                            /*NOLINT*/
+
+#ifdef DEBUG
+#define TRACE                                                                \
+    do {                                                                     \
+    printf( "(%3d) v0 %08x %08x\n",                               /*NOLINT*/ \
+        ( int )inlen, ( uint32_t )( v0 >> 32 ), ( uint32_t )v0 );            \
+    printf( "(%3d) v1 %08x %08x\n",                               /*NOLINT*/ \
+        ( int )inlen, ( uint32_t )( v1 >> 32 ), ( uint32_t )v1 );            \
+    printf( "(%3d) v2 %08x %08x\n",                               /*NOLINT*/ \
+        ( int )inlen, ( uint32_t )( v2 >> 32 ), ( uint32_t )v2 );            \
+    printf( "(%3d) v3 %08x %08x\n",                               /*NOLINT*/ \
+        ( int )inlen, ( uint32_t )( v3 >> 32 ), ( uint32_t )v3 );            \
+    } while(0)  /*NOLINT*/
+#else
+#define TRACE
+#endif
+
+int siphash(uint8_t *out, const uint8_t *in, uint64_t inlen, const uint8_t *k) {
+  /* "somepseudorandomlygeneratedbytes" */
+  uint64_t v0 = 0x736f6d6570736575ULL;
+  uint64_t v1 = 0x646f72616e646f6dULL;
+  uint64_t v2 = 0x6c7967656e657261ULL;
+  uint64_t v3 = 0x7465646279746573ULL;
+  uint64_t b;
+  uint64_t k0 = U8TO64_LE( k );  //NOLINT
+  uint64_t k1 = U8TO64_LE( k + 8 );  //NOLINT
+  uint64_t m;
+  int i;
+  const uint8_t *end = in + inlen - ( inlen % sizeof( uint64_t ) ); //NOLINT
+  const int left = inlen & 7;
+  b = ( ( uint64_t )inlen ) << 56;  //NOLINT
+  v3 ^= k1;
+  v2 ^= k0;
+  v1 ^= k1;
+  v0 ^= k0;
+
+#ifdef DOUBLE
+  v1 ^= 0xee;
+#endif
+
+  for (; in != end; in += 8) {
+    m = U8TO64_LE(in);
+    v3 ^= m;
+
+    TRACE;
+    for (i = 0; i < cROUNDS; ++i) SIPROUND;
+
+    v0 ^= m;
+  }
+
+  switch (left) {
+  case 7: b |= ( ( uint64_t )in[ 6] )  << 48;  //NOLINT
+  case 6: b |= ( ( uint64_t )in[ 5] )  << 40;  //NOLINT
+  case 5: b |= ( ( uint64_t )in[ 4] )  << 32;  //NOLINT
+  case 4: b |= ( ( uint64_t )in[ 3] )  << 24;  //NOLINT
+  case 3: b |= ( ( uint64_t )in[ 2] )  << 16;  //NOLINT
+  case 2: b |= ( ( uint64_t )in[ 1] )  <<  8;  //NOLINT
+  case 1: b |= ( ( uint64_t )in[ 0] ); break;  //NOLINT
+  case 0: break;
+  }
+
+
+  v3 ^= b;
+
+  TRACE;
+  for (i = 0; i < cROUNDS; ++i) SIPROUND;
+
+  v0 ^= b;
+
+#ifndef DOUBLE
+  v2 ^= 0xff;
+#else
+  v2 ^= 0xee;
+#endif
+
+  TRACE;
+  for (i = 0; i < dROUNDS; ++i) SIPROUND;
+
+  b = v0 ^ v1 ^ v2  ^ v3;
+  U64TO8_LE(out, b);
+
+#ifdef DOUBLE
+  v1 ^= 0xdd;
+
+  TRACE;
+  for (i = 0; i < dROUNDS; ++i) SIPROUND;
+
+  b = v0 ^ v1 ^ v2  ^ v3;
+  U64TO8_LE(out + 8, b);
+#endif
+
+  return 0;
+}
+
+std::array<std::uint8_t, 16> GetRandomSeed() {
+  std::array<std::uint8_t, 16> seed{{}};
+  CryptoPP::RandomNumberGenerator& random = maidsafe::crypto::random_number_generator();
+  random.GenerateBlock(seed.data(), seed.size());
+  return seed;
+}
+
+std::uint64_t SiphashReference(
+    const std::array<std::uint8_t, 16>& seed,
+    const char* in,
+    const std::uint64_t inlen) {
+  std::uint64_t out{};
+  siphash(
+      reinterpret_cast<std::uint8_t*>(&out),
+      reinterpret_cast<const std::uint8_t*>(in),
+      inlen,
+      seed.data());
+  return out;
+}
+
+}  // namespace
+
+TEST(SipHash, BEH_FixedString) {
+  const char test_string[] = "hash this string";
+  const unsigned string_size = sizeof(test_string) - 1;
+  const auto random_seed(GetRandomSeed());
+  const auto reference_hash(SiphashReference(random_seed, test_string, string_size));
+
+  // Split the string at every possible point
+  for (unsigned count = 0; count <= string_size; ++count) {
+    maidsafe::SipHash hash(random_seed);
+    hash.Update(reinterpret_cast<const std::uint8_t*>(test_string), count);
+    hash.Update(
+        reinterpret_cast<const std::uint8_t*>(test_string) + count, string_size - count);
+    EXPECT_EQ(reference_hash, hash.Finalize()) << "Failed on count " << count;
+  }
+
+  // Try byte at a time
+  {
+    maidsafe::SipHash hash(random_seed);
+    for (unsigned count = 0; count < string_size; ++count) {
+      hash.Update(reinterpret_cast<const std::uint8_t*>(&test_string[count]), 1);
+    }
+    EXPECT_EQ(reference_hash, hash.Finalize());
+  }
+}
+
+TEST(SipHash, BEH_RandomString) {
+  const std::string test_string(RandomString(1000));
+  const auto random_seed(GetRandomSeed());
+  const auto reference_hash(
+      SiphashReference(random_seed, test_string.data(), test_string.size()));
+
+  // Split the string at every possible point
+  for (unsigned count = 0; count <= test_string.size(); ++count) {
+    maidsafe::SipHash hash(random_seed);
+    hash.Update(reinterpret_cast<const std::uint8_t*>(test_string.data()), count);
+    hash.Update(
+        reinterpret_cast<const std::uint8_t*>(test_string.data()) + count,
+        test_string.size() - count);
+    EXPECT_EQ(reference_hash, hash.Finalize()) << "Failed on count " << count;
+  }
+
+  // Try byte at a time
+  {
+    maidsafe::SipHash hash(random_seed);
+    for (unsigned count = 0; count < test_string.size(); ++count) {
+      hash.Update(reinterpret_cast<const std::uint8_t*>(test_string.data() + count), 1);
+    }
+    EXPECT_EQ(reference_hash, hash.Finalize());
+  }
+}
+
+}  // namespace test
+}  // namespace maidsafe

--- a/src/maidsafe/common/hash/tests/siphash_test.cc
+++ b/src/maidsafe/common/hash/tests/siphash_test.cc
@@ -54,6 +54,11 @@ namespace {
    this software. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
  */
 
+#if defined(__clang__) || defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#endif
+
 /* default: SipHash-2-4 */
 #define cROUNDS 2
 #define dROUNDS 4
@@ -179,6 +184,10 @@ int siphash(uint8_t *out, const uint8_t *in, uint64_t inlen, const uint8_t *k) {
 
   return 0;
 }
+
+#if defined(__clang__) || defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
 std::array<byte, 16> GetRandomSeed() {
   std::array<byte, 16> seed{{}};


### PR DESCRIPTION
The N3980 differs the proposed in that it a serialize method will work with
both hashing, Cereal, and boost::serialization.