### PR TITLE
MAID-588 bug fix node_id.h unused variable warning

### DIFF
--- a/include/maidsafe/common/node_id.h
+++ b/include/maidsafe/common/node_id.h
@@ -39,7 +39,7 @@ class NodeId {
 
   NodeId(const NodeId& other);
   NodeId(NodeId&& other) MAIDSAFE_NOEXCEPT;
-  NodeId& operator=(const NodeId& other) = default;
+  NodeId& operator=(const NodeId&) = default;
   NodeId& operator=(NodeId&& other) MAIDSAFE_NOEXCEPT;
 
   // Creates a NodeId from a raw (decoded) string.  Will throw if 'id' is invalid.


### PR DESCRIPTION
...ator=(const DataMap&) = default;

just modifying to:
NodeId& operator=(const NodeId&) = default;

Now the builds are fine for arm-gcc as well.
